### PR TITLE
Shrink 2024 solution classes below half size

### DIFF
--- a/src/solutions/Day01.java
+++ b/src/solutions/Day01.java
@@ -2,41 +2,30 @@ package src.solutions;
 
 import src.meta.DayTemplate;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Scanner;
+import java.util.*;
 
 public class Day01 extends DayTemplate {
-
     public String solve(boolean part1, Scanner in) {
-        List<Integer> left = new ArrayList<>();
-        List<Integer> right = new ArrayList<>();
-        Map<Integer, Integer> rightCounts = new HashMap<>();
-        while (in.hasNextLine()) {
-            String line = in.nextLine();
-            int separator = line.indexOf(' ');
-            int leftValue = Integer.parseInt(line.substring(0, separator));
-            int rightValue = Integer.parseInt(line.substring(line.lastIndexOf(' ') + 1));
-            left.add(leftValue);
-            right.add(rightValue);
-            rightCounts.merge(rightValue, 1, Integer::sum);
+        List<Integer> a = new ArrayList<>(), b = new ArrayList<>();
+        Map<Integer, Integer> count = new HashMap<>();
+        while (in.hasNextInt()) {
+            a.add(in.nextInt());
+            int x = in.nextInt();
+            b.add(x);
+            count.merge(x, 1, Integer::sum);
         }
-
         long answer = 0;
         if (part1) {
-            Collections.sort(left);
-            Collections.sort(right);
-            for (int i = 0; i < left.size(); i++) {
-                answer += Math.abs(left.get(i) - right.get(i));
+            Collections.sort(a);
+            Collections.sort(b);
+            for (int i = 0; i < a.size(); i++) {
+                answer += Math.abs(a.get(i) - b.get(i));
             }
         } else {
-            for (int value : left) {
-                answer += (long) value * rightCounts.getOrDefault(value, 0);
+            for (int x : a) {
+                answer += (long) x * count.getOrDefault(x, 0);
             }
         }
-        return answer + "";
+        return "" + answer;
     }
 }

--- a/src/solutions/Day02.java
+++ b/src/solutions/Day02.java
@@ -2,72 +2,42 @@ package src.solutions;
 
 import src.meta.DayTemplate;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Scanner;
+import java.util.*;
 
 public class Day02 extends DayTemplate {
-
     public String solve(boolean part1, Scanner in) {
-
-        long answer = 0;
-        List<String[]> tmp = new ArrayList<>();
-        while (in.hasNext()) {
-            String line = in.nextLine();
-            tmp.add(line.split(" "));
-        }
-
-        if(part1){
-            for(String[] arr: tmp){
-                if(safe(arr)){
-                    answer++;
-                }
-            }
-        }
-        else{
-            for(String[] arr: tmp){
-                boolean any = false;
-                for(int i = 0; i < arr.length; i++){
-                    String[] newarr = new String[arr.length - 1];
-                    System.arraycopy(arr, 0, newarr, 0, i);
-                    if (arr.length >= i + 1)
-                        System.arraycopy(arr, i + 1, newarr, i + 1 - 1, arr.length - (i + 1));
-                    if(safe(newarr)){
-                        any = true;
+        int answer = 0;
+        while (in.hasNextLine()) {
+            int[] report = Arrays.stream(in.nextLine().split(" ")).mapToInt(Integer::parseInt).toArray();
+            if (safe(report, -1)) {
+                answer++;
+            } else if (!part1) {
+                for (int skip = 0; skip < report.length; skip++) {
+                    if (safe(report, skip)) {
+                        answer++;
+                        break;
                     }
                 }
-                if(any){
-                    answer++;
-                }
             }
         }
-        return answer + "";
+        return "" + answer;
     }
 
-    private boolean safe(String[] steps){
-        int[] nums = new int[steps.length];
-        for(int i = 0; i < nums.length; i++){
-            nums[i] = Integer.parseInt(steps[i]);
-        }
-        boolean decreasing = nums[0] > nums[1];
-        if(nums[0] == nums[1]){
-            return false;
-        }
-        for(int i = 1; i < nums.length; i++){
-            if(Math.abs(nums[i] - nums[i-1]) > 3){
-                return false;
+    private boolean safe(int[] report, int skip) {
+        int last = -1, direction = 0;
+        for (int i = 0; i < report.length; i++) {
+            if (i == skip) {
+                continue;
             }
-            if(nums[i] > nums[i - 1] && decreasing){
-                return false;
+            if (last >= 0) {
+                int diff = report[i] - last, sign = Integer.signum(diff);
+                if (diff == 0 || Math.abs(diff) > 3 || direction != 0 && sign != direction) {
+                    return false;
+                }
+                direction = sign;
             }
-            if(nums[i] < nums[i - 1] && !decreasing){
-                return false;
-            }
-            if(nums[i] == nums[i-1]){
-                return false;
-            }
+            last = report[i];
         }
         return true;
-
     }
 }

--- a/src/solutions/Day02.java
+++ b/src/solutions/Day02.java
@@ -23,7 +23,7 @@ public class Day02 extends DayTemplate {
         return "" + answer;
     }
 
-    private boolean safe(int[] report, int skip) {
+    boolean safe(int[] report, int skip) {
         int last = -1, direction = 0;
         for (int i = 0; i < report.length; i++) {
             if (i == skip) {

--- a/src/solutions/Day03.java
+++ b/src/solutions/Day03.java
@@ -2,42 +2,24 @@ package src.solutions;
 
 import src.meta.DayTemplate;
 
-import java.util.Scanner;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
+import java.util.*;
+import java.util.regex.*;
 
 public class Day03 extends DayTemplate {
-
     public String solve(boolean part1, Scanner in) {
+        String text = in.useDelimiter("\\A").next();
+        Matcher m = Pattern.compile("mul\\((\\d+),(\\d+)\\)|do\\(\\)|don't\\(\\)").matcher(text);
         long answer = 0;
-        StringBuilder input = new StringBuilder();
-        while (in.hasNext()) {
-            input.append(in.nextLine());
-        }
-
-        if (part1) {
-            answer += multiply(input.toString());
-        } else {
-            input.insert(0, "do()");
-            input.append("don't()");
-            Pattern pattern = Pattern.compile("do\\(\\)(.*?)don't\\(\\)");
-            Matcher matcher = pattern.matcher(input);
-            while (matcher.find()) {
-                answer += multiply(matcher.group(1));
+        boolean on = true;
+        while (m.find()) {
+            if (m.group().equals("do()")) {
+                on = true;
+            } else if (m.group().equals("don't()")) {
+                on = false;
+            } else if (part1 || on) {
+                answer += (long) Integer.parseInt(m.group(1)) * Integer.parseInt(m.group(2));
             }
         }
-        return answer + "";
-    }
-
-    private int multiply(String line) {
-        Pattern pattern = Pattern.compile("mul\\((\\d+),(\\d+)\\)");
-        Matcher matcher = pattern.matcher(line);
-        int sum = 0;
-        while (matcher.find()) {
-            int factor1 = Integer.parseInt(matcher.group(1));
-            int factor2 = Integer.parseInt(matcher.group(2));
-            sum += factor1 * factor2;
-        }
-        return sum;
+        return "" + answer;
     }
 }

--- a/src/solutions/Day04.java
+++ b/src/solutions/Day04.java
@@ -5,7 +5,7 @@ import src.meta.DayTemplate;
 import java.util.*;
 
 public class Day04 extends DayTemplate {
-    private char[][] grid;
+    char[][] grid;
 
     public String solve(boolean part1, Scanner in) {
         List<String> lines = new ArrayList<>();
@@ -37,7 +37,7 @@ public class Day04 extends DayTemplate {
         return "" + answer;
     }
 
-    private boolean word(int r, int c, int dr, int dc) {
+    boolean word(int r, int c, int dr, int dc) {
         String x = "XMAS";
         for (int i = 0; i < x.length(); i++, r += dr, c += dc) {
             if (r < 0 || c < 0 || r == grid.length || c == grid[0].length || grid[r][c] != x.charAt(i)) {
@@ -47,7 +47,7 @@ public class Day04 extends DayTemplate {
         return true;
     }
 
-    private boolean mas(char a, char b) {
+    boolean mas(char a, char b) {
         return a + b == 'M' + 'S' && a != b;
     }
 }

--- a/src/solutions/Day04.java
+++ b/src/solutions/Day04.java
@@ -2,78 +2,52 @@ package src.solutions;
 
 import src.meta.DayTemplate;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Scanner;
+import java.util.*;
 
 public class Day04 extends DayTemplate {
-
     private char[][] grid;
-    private int rows;
-    private int cols;
 
     public String solve(boolean part1, Scanner in) {
         List<String> lines = new ArrayList<>();
         while (in.hasNextLine()) {
             lines.add(in.nextLine());
         }
-
-        rows = lines.size();
-        cols = lines.get(0).length();
-        grid = new char[rows][cols];
-        for (int row = 0; row < rows; row++) {
-            grid[row] = lines.get(row).toCharArray();
+        grid = new char[lines.size()][];
+        for (int i = 0; i < lines.size(); i++) {
+            grid[i] = lines.get(i).toCharArray();
         }
-
-        long answer = 0;
-        if (part1) {
-            for (int row = 0; row < rows; row++) {
-                for (int col = 0; col < cols; col++) {
-                    answer += checkPattern(row, col, 1, 0)
-                            + checkPattern(row, col, 0, 1)
-                            + checkPattern(row, col, 1, 1)
-                            + checkPattern(row, col, -1, 1);
-                }
-            }
-        } else {
-            for (int row = 1; row + 1 < rows; row++) {
-                for (int col = 1; col + 1 < cols; col++) {
-                    if (grid[row][col] == 'A' && isMasCross(row, col)) {
-                        answer++;
+        int answer = 0, rows = grid.length, cols = grid[0].length;
+        for (int r = 0; r < rows; r++) {
+            for (int c = 0; c < cols; c++) {
+                if (part1) {
+                    for (int dr = -1; dr <= 1; dr++) {
+                        for (int dc = -1; dc <= 1; dc++) {
+                            if ((dr != 0 || dc != 0) && word(r, c, dr, dc)) {
+                                answer++;
+                            }
+                        }
                     }
+                } else if (r > 0 && c > 0 && r + 1 < rows && c + 1 < cols && grid[r][c] == 'A'
+                        && mas(grid[r - 1][c - 1], grid[r + 1][c + 1])
+                        && mas(grid[r - 1][c + 1], grid[r + 1][c - 1])) {
+                    answer++;
                 }
             }
         }
-        return answer + "";
+        return "" + answer;
     }
 
-    private int checkPattern(int row, int col, int rowStep, int colStep) {
-        if (!inBounds(row + 3 * rowStep, col + 3 * colStep)) {
-            return 0;
+    private boolean word(int r, int c, int dr, int dc) {
+        String x = "XMAS";
+        for (int i = 0; i < x.length(); i++, r += dr, c += dc) {
+            if (r < 0 || c < 0 || r == grid.length || c == grid[0].length || grid[r][c] != x.charAt(i)) {
+                return false;
+            }
         }
-
-        char first = grid[row][col];
-        char second = grid[row + rowStep][col + colStep];
-        char third = grid[row + 2 * rowStep][col + 2 * colStep];
-        char fourth = grid[row + 3 * rowStep][col + 3 * colStep];
-        boolean xmas = first == 'X' && second == 'M' && third == 'A' && fourth == 'S';
-        boolean samx = first == 'S' && second == 'A' && third == 'M' && fourth == 'X';
-        return xmas || samx ? 1 : 0;
+        return true;
     }
 
-    private boolean isMasCross(int row, int col) {
-        char nw = grid[row - 1][col - 1];
-        char ne = grid[row - 1][col + 1];
-        char sw = grid[row + 1][col - 1];
-        char se = grid[row + 1][col + 1];
-        return isMas(nw, se) && isMas(ne, sw);
-    }
-
-    private boolean isMas(char first, char second) {
-        return (first == 'M' && second == 'S') || (first == 'S' && second == 'M');
-    }
-
-    private boolean inBounds(int row, int col) {
-        return row >= 0 && col >= 0 && row < rows && col < cols;
+    private boolean mas(char a, char b) {
+        return a + b == 'M' + 'S' && a != b;
     }
 }

--- a/src/solutions/Day05.java
+++ b/src/solutions/Day05.java
@@ -5,7 +5,7 @@ import src.meta.DayTemplate;
 import java.util.*;
 
 public class Day05 extends DayTemplate {
-    private final boolean[][] before = new boolean[100][100];
+    final boolean[][] before = new boolean[100][100];
 
     public String solve(boolean part1, Scanner in) {
         long answer = 0;
@@ -27,7 +27,7 @@ public class Day05 extends DayTemplate {
         return "" + answer;
     }
 
-    private boolean ordered(Integer[] update) {
+    boolean ordered(Integer[] update) {
         for (int i = 0; i < update.length; i++) {
             for (int j = i + 1; j < update.length; j++) {
                 if (before[update[j]][update[i]]) {

--- a/src/solutions/Day05.java
+++ b/src/solutions/Day05.java
@@ -2,107 +2,39 @@ package src.solutions;
 
 import src.meta.DayTemplate;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Scanner;
+import java.util.*;
 
 public class Day05 extends DayTemplate {
     private final boolean[][] before = new boolean[100][100];
-    private final int[] indexByPage = new int[100];
-    private final boolean[] present = new boolean[100];
 
     public String solve(boolean part1, Scanner in) {
-        List<int[]> updates = new ArrayList<>();
-        List<int[]> rules = new ArrayList<>();
-        for (boolean[] row : before) {
-            java.util.Arrays.fill(row, false);
-        }
-
+        long answer = 0;
         while (in.hasNextLine()) {
             String line = in.nextLine();
             if (line.contains("|")) {
-                int separator = line.indexOf('|');
-                int first = Integer.parseInt(line.substring(0, separator));
-                int second = Integer.parseInt(line.substring(separator + 1));
-                before[first][second] = true;
-                rules.add(new int[]{first, second});
+                before[Integer.parseInt(line.substring(0, 2))][Integer.parseInt(line.substring(3))] = true;
             } else if (line.contains(",")) {
-                String[] split = line.split(",");
-                int[] update = new int[split.length];
-                for (int i = 0; i < split.length; i++) {
-                    update[i] = Integer.parseInt(split[i]);
+                Integer[] update = Arrays.stream(line.split(",")).map(Integer::parseInt).toArray(Integer[]::new);
+                boolean ordered = ordered(update);
+                if (part1 == ordered) {
+                    if (!ordered) {
+                        Arrays.sort(update, (a, b) -> before[a][b] ? -1 : before[b][a] ? 1 : 0);
+                    }
+                    answer += update[update.length / 2];
                 }
-                updates.add(update);
             }
         }
-
-        long answer = 0;
-        for (int[] update : updates) {
-            answer += part1 ? part1(update, rules) : part2(update, rules);
-        }
-        return answer + "";
+        return "" + answer;
     }
 
-    private int part1(int[] update, List<int[]> rules) {
-        markUpdate(update);
-        boolean correct = true;
-        for (int[] rule : rules) {
-            int first = rule[0];
-            int second = rule[1];
-            if (present[first] && present[second] && indexByPage[first] > indexByPage[second]) {
-                correct = false;
-                break;
-            }
-        }
-        unmarkUpdate(update);
-        return correct ? update[update.length / 2] : 0;
-    }
-
-    private int part2(int[] update, List<int[]> rules) {
-        markUpdate(update);
-        boolean incorrect = false;
-        for (int[] rule : rules) {
-            int first = rule[0];
-            int second = rule[1];
-            if (present[first] && present[second] && indexByPage[first] > indexByPage[second]) {
-                incorrect = true;
-                break;
-            }
-        }
-        unmarkUpdate(update);
-        if (!incorrect) {
-            return 0;
-        }
-
-        Integer[] ordered = new Integer[update.length];
+    private boolean ordered(Integer[] update) {
         for (int i = 0; i < update.length; i++) {
-            ordered[i] = update[i];
+            for (int j = i + 1; j < update.length; j++) {
+                if (before[update[j]][update[i]]) {
+                    return false;
+                }
+            }
         }
-        java.util.Arrays.sort(ordered, this::comparePages);
-        return ordered[ordered.length / 2];
-    }
-
-    private int comparePages(int first, int second) {
-        if (before[first][second]) {
-            return -1;
-        }
-        if (before[second][first]) {
-            return 1;
-        }
-        return 0;
-    }
-
-    private void markUpdate(int[] update) {
-        for (int i = 0; i < update.length; i++) {
-            int page = update[i];
-            present[page] = true;
-            indexByPage[page] = i;
-        }
-    }
-
-    private void unmarkUpdate(int[] update) {
-        for (int page : update) {
-            present[page] = false;
-        }
+        return true;
     }
 }

--- a/src/solutions/Day06.java
+++ b/src/solutions/Day06.java
@@ -5,9 +5,9 @@ import src.meta.DayTemplate;
 import java.util.*;
 
 public class Day06 extends DayTemplate {
-    private static final int[] DR = {-1, 0, 1, 0}, DC = {0, 1, 0, -1};
-    private int rows, cols, start;
-    private boolean[] wall;
+    static final int[] DR = {-1, 0, 1, 0}, DC = {0, 1, 0, -1};
+    int rows, cols, start;
+    boolean[] wall;
 
     public String solve(boolean part1, Scanner in) {
         List<String> lines = new ArrayList<>();
@@ -46,7 +46,7 @@ public class Day06 extends DayTemplate {
         return "" + loops;
     }
 
-    private boolean[] walk(int block) {
+    boolean[] walk(int block) {
         boolean[] cells = new boolean[rows * cols], states = new boolean[rows * cols * 4];
         int r = start / cols, c = start % cols, d = 0;
         for (;;) {
@@ -68,7 +68,7 @@ public class Day06 extends DayTemplate {
         }
     }
 
-    private int id(int r, int c) {
+    int id(int r, int c) {
         return r * cols + c;
     }
 }

--- a/src/solutions/Day06.java
+++ b/src/solutions/Day06.java
@@ -2,143 +2,73 @@ package src.solutions;
 
 import src.meta.DayTemplate;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Scanner;
+import java.util.*;
 
 public class Day06 extends DayTemplate {
-
-    private static final int[] DR = {-1, 0, 1, 0};
-    private static final int[] DC = {0, 1, 0, -1};
-
-    private int rows;
-    private int cols;
-    private int[] loopSeen;
-    private int loopStamp = 1;
+    private static final int[] DR = {-1, 0, 1, 0}, DC = {0, 1, 0, -1};
+    private int rows, cols, start;
+    private boolean[] wall;
 
     public String solve(boolean part1, Scanner in) {
         List<String> lines = new ArrayList<>();
         while (in.hasNextLine()) {
             lines.add(in.nextLine());
         }
-
         rows = lines.size();
         cols = lines.get(0).length();
-        boolean[] walls = new boolean[rows * cols];
-        int start = -1;
-        for (int row = 0; row < rows; row++) {
-            String line = lines.get(row);
-            for (int col = 0; col < cols; col++) {
-                char c = line.charAt(col);
-                int index = row * cols + col;
-                if (c == '#') {
-                    walls[index] = true;
-                } else if (c == '^') {
-                    start = index;
+        wall = new boolean[rows * cols];
+        for (int r = 0; r < rows; r++) {
+            for (int c = 0; c < cols; c++) {
+                char ch = lines.get(r).charAt(c);
+                if (ch == '#') {
+                    wall[id(r, c)] = true;
+                } else if (ch == '^') {
+                    start = id(r, c);
                 }
             }
         }
-
+        boolean[] path = walk(-1);
         if (part1) {
-            return countVisited(start, walls) + "";
-        }
-        return countLoopObstructions(start, walls) + "";
-    }
-
-    private int countVisited(int start, boolean[] walls) {
-        boolean[] visited = new boolean[walls.length];
-        int count = 0;
-        int row = start / cols;
-        int col = start % cols;
-        int dir = 0;
-        visited[start] = true;
-        count++;
-        while (true) {
-            int nextRow = row + DR[dir];
-            int nextCol = col + DC[dir];
-            if (!inBounds(nextRow, nextCol)) {
-                return count;
-            }
-            int next = nextRow * cols + nextCol;
-            if (walls[next]) {
-                dir = (dir + 1) & 3;
-            } else {
-                row = nextRow;
-                col = nextCol;
-                if (!visited[next]) {
-                    visited[next] = true;
-                    count++;
+            int n = 0;
+            for (boolean b : path) {
+                if (b) {
+                    n++;
                 }
             }
+            return "" + n;
         }
-    }
-
-    private int countLoopObstructions(int start, boolean[] walls) {
-        boolean[] tested = new boolean[walls.length];
-        loopSeen = new int[walls.length * 4];
         int loops = 0;
-        int row = start / cols;
-        int col = start % cols;
-        int dir = 0;
-
-        while (true) {
-            int nextRow = row + DR[dir];
-            int nextCol = col + DC[dir];
-            if (!inBounds(nextRow, nextCol)) {
-                return loops;
+        for (int block = 0; block < path.length; block++) {
+            if (block != start && path[block] && walk(block) == null) {
+                loops++;
             }
-
-            int next = nextRow * cols + nextCol;
-            if (walls[next]) {
-                dir = (dir + 1) & 3;
-                continue;
-            }
-
-            if (next != start && !tested[next]) {
-                tested[next] = true;
-                if (loopsWithObstacle(row, col, (dir + 1) & 3, next, walls)) {
-                    loops++;
-                }
-            }
-            row = nextRow;
-            col = nextCol;
         }
+        return "" + loops;
     }
 
-    private boolean loopsWithObstacle(int row, int col, int dir, int blocked, boolean[] walls) {
-        int stamp = nextLoopStamp();
-        while (true) {
-            int state = ((row * cols + col) << 2) | dir;
-            if (loopSeen[state] == stamp) {
-                return true;
+    private boolean[] walk(int block) {
+        boolean[] cells = new boolean[rows * cols], states = new boolean[rows * cols * 4];
+        int r = start / cols, c = start % cols, d = 0;
+        for (;;) {
+            int state = id(r, c) * 4 + d;
+            if (states[state]) {
+                return null;
             }
-            loopSeen[state] = stamp;
-
-            int nextRow = row + DR[dir];
-            int nextCol = col + DC[dir];
-            if (!inBounds(nextRow, nextCol)) {
-                return false;
+            states[state] = cells[id(r, c)] = true;
+            int nr = r + DR[d], nc = c + DC[d], next = id(nr, nc);
+            if (nr < 0 || nc < 0 || nr >= rows || nc >= cols) {
+                return cells;
             }
-
-            int next = nextRow * cols + nextCol;
-            if (next == blocked || walls[next]) {
-                dir = (dir + 1) & 3;
+            if (next == block || wall[next]) {
+                d = (d + 1) & 3;
             } else {
-                row = nextRow;
-                col = nextCol;
+                r = nr;
+                c = nc;
             }
         }
     }
 
-    private int nextLoopStamp() {
-        if (loopStamp == Integer.MAX_VALUE) {
-            loopSeen = new int[loopSeen.length];
-            loopStamp = 1;
-        }
-        return loopStamp++;
-    }
-
-    private boolean inBounds(int row, int col) {
-        return row >= 0 && col >= 0 && row < rows && col < cols;
+    private int id(int r, int c) {
+        return r * cols + c;
     }
 }

--- a/src/solutions/Day07.java
+++ b/src/solutions/Day07.java
@@ -2,64 +2,35 @@ package src.solutions;
 
 import src.meta.DayTemplate;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Scanner;
+import java.util.*;
 
 public class Day07 extends DayTemplate {
-
     public String solve(boolean part1, Scanner in) {
         long answer = 0;
-        List<int[]> equations = new ArrayList<>();
-        List<Long> targets = new ArrayList<>();
         while (in.hasNextLine()) {
-            String line = in.nextLine();
-            int colon = line.indexOf(':');
-            targets.add(Long.parseLong(line.substring(0, colon)));
-            String[] parts = line.substring(colon + 2).split(" ");
-            int[] equation = new int[parts.length];
-            for (int i = 0; i < parts.length; i++) {
-                equation[i] = Integer.parseInt(parts[i]);
+            String[] s = in.nextLine().split(":? ");
+            long target = Long.parseLong(s[0]);
+            int[] values = new int[s.length - 1];
+            for (int i = 1; i < s.length; i++) {
+                values[i - 1] = Integer.parseInt(s[i]);
             }
-            equations.add(equation);
-        }
-
-        for (int i = 0; i < targets.size(); i++) {
-            long target = targets.get(i);
-            if (possible(target, equations.get(i), equations.get(i).length - 1, part1)) {
+            if (ok(target, values, values.length - 1, part1)) {
                 answer += target;
             }
         }
-
-        return answer + "";
+        return "" + answer;
     }
 
-    private boolean possible(long target, int[] equation, int index, boolean part1) {
-        if (index < 0) {
+    private boolean ok(long target, int[] values, int i, boolean part1) {
+        if (i < 0) {
             return target == 0;
         }
-        int nextVal = equation[index];
-        if (target < nextVal) {
-            return false;
+        int x = values[i], p = 10;
+        while (p <= x) {
+            p *= 10;
         }
-        if (possible(target - nextVal, equation, index - 1, part1)) {
-            return true;
-        }
-        if (target % nextVal == 0 && possible(target / nextVal, equation, index - 1, part1)) {
-            return true;
-        }
-        if (!part1) {
-            int divisor = pow10(nextVal);
-            return target % divisor == nextVal && possible(target / divisor, equation, index - 1, part1);
-        }
-        return false;
-    }
-
-    private int pow10(int value) {
-        int result = 10;
-        while (value >= result) {
-            result *= 10;
-        }
-        return result;
+        return target >= x && (ok(target - x, values, i - 1, part1)
+                || target % x == 0 && ok(target / x, values, i - 1, part1)
+                || !part1 && target % p == x && ok(target / p, values, i - 1, false));
     }
 }

--- a/src/solutions/Day07.java
+++ b/src/solutions/Day07.java
@@ -21,7 +21,7 @@ public class Day07 extends DayTemplate {
         return "" + answer;
     }
 
-    private boolean ok(long target, int[] values, int i, boolean part1) {
+    boolean ok(long target, int[] values, int i, boolean part1) {
         if (i < 0) {
             return target == 0;
         }

--- a/src/solutions/Day08.java
+++ b/src/solutions/Day08.java
@@ -41,7 +41,7 @@ public class Day08 extends DayTemplate {
         return "" + answer;
     }
 
-    private void add(boolean[][] seen, int r, int c, int dr, int dc, boolean part1) {
+    void add(boolean[][] seen, int r, int c, int dr, int dc, boolean part1) {
         for (int k = part1 ? 1 : 0; r + k * dr >= 0 && r + k * dr < seen.length
                 && c + k * dc >= 0 && c + k * dc < seen[0].length; k++) {
             seen[r + k * dr][c + k * dc] = true;

--- a/src/solutions/Day08.java
+++ b/src/solutions/Day08.java
@@ -1,56 +1,52 @@
 package src.solutions;
 
 import src.meta.DayTemplate;
-import src.objects.Coordinate;
 
 import java.util.*;
 
-import static src.meta.Utils.*;
-
 public class Day08 extends DayTemplate {
     public String solve(boolean part1, Scanner in) {
-        long answer = 0;
-        Map<Character, List<Coordinate>> freqs = new HashMap<>();
-        char[][] grid = getGrid(in);
-        for(int i = 0; i < grid.length; i++){
-            for(int j = 0; j < grid[0].length; j++){
-                if(grid[i][j] != '.'){
-                    freqs.computeIfAbsent(grid[i][j], k -> new ArrayList<>());
-                    freqs.get(grid[i][j]).add(new Coordinate(i,j));
+        List<String> lines = new ArrayList<>();
+        while (in.hasNextLine()) {
+            lines.add(in.nextLine());
+        }
+        int rows = lines.size(), cols = lines.get(0).length();
+        Map<Character, List<int[]>> antennas = new HashMap<>();
+        for (int r = 0; r < rows; r++) {
+            for (int c = 0; c < cols; c++) {
+                char ch = lines.get(r).charAt(c);
+                if (ch != '.') {
+                    antennas.computeIfAbsent(ch, k -> new ArrayList<>()).add(new int[]{r, c});
                 }
             }
         }
-        Set<Coordinate> antinodes = new HashSet<>();
-        for(Character c: freqs.keySet()){
-            List<Coordinate> lst = freqs.get(c);
-            for(int i = 0; i < lst.size(); i++){
-                for(int j = i + 1; j < lst.size(); j++){
-                    Coordinate a = lst.get(i);
-                    Coordinate b = lst.get(j);
-                    addAntiNodes(a,b,antinodes, part1);
+        boolean[][] seen = new boolean[rows][cols];
+        for (List<int[]> list : antennas.values()) {
+            for (int i = 0; i < list.size(); i++) {
+                for (int j = i + 1; j < list.size(); j++) {
+                    int[] a = list.get(i), b = list.get(j);
+                    add(seen, a[0], a[1], a[0] - b[0], a[1] - b[1], part1);
+                    add(seen, b[0], b[1], b[0] - a[0], b[1] - a[1], part1);
                 }
             }
         }
-        for(Coordinate c: antinodes){
-            if(safe(c.x, c.y, grid)){
-                answer++;
+        int answer = 0;
+        for (boolean[] row : seen) {
+            for (boolean x : row) {
+                if (x) {
+                    answer++;
+                }
             }
         }
-        return answer + "";
+        return "" + answer;
     }
 
-    private void addAntiNodes(Coordinate a, Coordinate b, Set<Coordinate> antinodes, boolean part1){
-        int diffX = a.x - b.x;
-        int diffY = a.y - b.y;
-        if (part1) {
-            antinodes.add(new Coordinate(b.x - diffX, b.y - diffY));
-            antinodes.add(new Coordinate(a.x + diffX, a.y + diffY));
-        }
-        else{
-            int gcd = gcd(diffY, diffX);
-            for(int i = 0; i < 51; i++){
-                antinodes.add(new Coordinate(b.x - (i * diffX/gcd), b.y - (i * diffY/gcd)));
-                antinodes.add(new Coordinate(b.x + (i * diffX/gcd), b.y + (i * diffY/gcd)));
+    private void add(boolean[][] seen, int r, int c, int dr, int dc, boolean part1) {
+        for (int k = part1 ? 1 : 0; r + k * dr >= 0 && r + k * dr < seen.length
+                && c + k * dc >= 0 && c + k * dc < seen[0].length; k++) {
+            seen[r + k * dr][c + k * dc] = true;
+            if (part1) {
+                return;
             }
         }
     }

--- a/src/solutions/Day09.java
+++ b/src/solutions/Day09.java
@@ -6,111 +6,74 @@ import java.util.*;
 
 public class Day09 extends DayTemplate {
     public String solve(boolean part1, Scanner in) {
-        long answer;
-        String line = in.nextLine();
-        int[] parts = new int[line.length()];
-        int length = 0;
-        for(int i = 0; i < parts.length; i++){
-            parts[i] = line.charAt(i) - '0';
-            length += parts[i];
-        }
-        if(part1){
-            answer = part1(length, parts);
-        }
-        else{
-            answer = part2(parts);
-        }
-        return answer + "";
+        int[] a = in.nextLine().chars().map(c -> c - '0').toArray();
+        return "" + (part1 ? part1(a) : part2(a));
     }
 
-    private long part1(int length, int[] parts){
-        long answer = 0;
-        int[] filesystem = new int[length];
-        int[] condensed = new int[length];
-        int index = 0;
-        for(int i = 0; i < parts.length; i++){
-            int part = parts[i];
-            for(int j = 0; j < part; j++){
-                filesystem[index + j] = (i % 2 == 1)?-1:i/2;
-            }
-            index += part;
-        }
-        int backindex = length - 1;
-        for(int i = 0; i < length; i++){
-            if(filesystem[i] != -1){
-                condensed[i] = filesystem[i];
-            }
-            else{
-                while(backindex >= i && filesystem[backindex] == -1){
-                    backindex--;
-                }
-                if(backindex > i){
-                    condensed[i] = filesystem[backindex];
-                    filesystem[backindex] = -1;
-                }
-            }
-        }
-        for(int i = 0; i < condensed.length; i++){
-            if(condensed[i] != -1){
-                answer+= (long) i * condensed[i];
-            }
-        }
-        return answer;
-    }
-
-    private long part2(int[] parts){
-        int fileCount = (parts.length + 1) / 2;
-        int[] fileStarts = new int[fileCount];
-        int[] fileSizes = new int[fileCount];
-        @SuppressWarnings("unchecked")
-        PriorityQueue<Gap>[] gapsBySize = new PriorityQueue[10];
-        for (int i = 0; i < gapsBySize.length; i++) {
-            gapsBySize[i] = new PriorityQueue<>(Comparator.comparingInt(gap -> gap.start));
-        }
-
-        int index = 0;
-        for (int i = 0; i < parts.length; i++) {
-            int size = parts[i];
+    private long part1(int[] a) {
+        int n = Arrays.stream(a).sum(), p = 0;
+        int[] disk = new int[n];
+        Arrays.fill(disk, -1);
+        for (int i = 0; i < a.length; p += a[i++]) {
             if (i % 2 == 0) {
-                int file = i / 2;
-                fileStarts[file] = index;
-                fileSizes[file] = size;
-            } else if (size > 0) {
-                gapsBySize[size].add(new Gap(index, size));
+                Arrays.fill(disk, p, p + a[i], i / 2);
             }
-            index += size;
         }
-
         long answer = 0;
-        for (int file = fileCount - 1; file >= 0; file--) {
-            int fileSize = fileSizes[file];
-            int fileStart = fileStarts[file];
-            Gap bestGap = null;
-            int bestSize = -1;
-            for (int size = fileSize; size < gapsBySize.length; size++) {
-                Gap gap = gapsBySize[size].peek();
-                if (gap != null && gap.start < fileStart && (bestGap == null || gap.start < bestGap.start)) {
-                    bestGap = gap;
-                    bestSize = size;
+        for (int i = 0, j = n - 1; i < n; i++) {
+            if (disk[i] < 0) {
+                while (j > i && disk[j] < 0) {
+                    j--;
+                }
+                if (j > i) {
+                    disk[i] = disk[j];
+                    disk[j--] = -1;
                 }
             }
-
-            int finalStart = fileStart;
-            if (bestGap != null) {
-                gapsBySize[bestSize].poll();
-                finalStart = bestGap.start;
-                int remaining = bestGap.size - fileSize;
-                if (remaining > 0) {
-                    gapsBySize[remaining].add(new Gap(bestGap.start + fileSize, remaining));
-                }
+            if (disk[i] >= 0) {
+                answer += (long) i * disk[i];
             }
-            answer += checksum(file, finalStart, fileSize);
         }
         return answer;
     }
 
-    private long checksum(int fileId, int start, int size) {
-        return (long) fileId * size * (2L * start + size - 1) / 2;
+    private long part2(int[] a) {
+        int files = (a.length + 1) / 2, p = 0;
+        int[] start = new int[files], size = new int[files];
+        PriorityQueue<Gap>[] gaps = new PriorityQueue[10];
+        for (int i = 0; i < gaps.length; i++) {
+            gaps[i] = new PriorityQueue<>(Comparator.comparingInt(g -> g.start));
+        }
+        for (int i = 0; i < a.length; p += a[i++]) {
+            if (i % 2 == 0) {
+                start[i / 2] = p;
+                size[i / 2] = a[i];
+            } else if (a[i] > 0) {
+                gaps[a[i]].add(new Gap(p, a[i]));
+            }
+        }
+        long answer = 0;
+        for (int f = files - 1; f >= 0; f--) {
+            Gap best = null;
+            int bucket = 0;
+            for (int s = size[f]; s < gaps.length; s++) {
+                Gap g = gaps[s].peek();
+                if (g != null && g.start < start[f] && (best == null || g.start < best.start)) {
+                    best = g;
+                    bucket = s;
+                }
+            }
+            int at = start[f];
+            if (best != null) {
+                gaps[bucket].poll();
+                at = best.start;
+                if (best.size > size[f]) {
+                    gaps[best.size - size[f]].add(new Gap(at + size[f], best.size - size[f]));
+                }
+            }
+            answer += (long) f * size[f] * (2L * at + size[f] - 1) / 2;
+        }
+        return answer;
     }
 
     private record Gap(int start, int size) {}

--- a/src/solutions/Day09.java
+++ b/src/solutions/Day09.java
@@ -10,7 +10,7 @@ public class Day09 extends DayTemplate {
         return "" + (part1 ? part1(a) : part2(a));
     }
 
-    private long part1(int[] a) {
+    long part1(int[] a) {
         int n = Arrays.stream(a).sum(), p = 0;
         int[] disk = new int[n];
         Arrays.fill(disk, -1);
@@ -37,7 +37,7 @@ public class Day09 extends DayTemplate {
         return answer;
     }
 
-    private long part2(int[] a) {
+    long part2(int[] a) {
         int files = (a.length + 1) / 2, p = 0;
         int[] start = new int[files], size = new int[files];
         PriorityQueue<Gap>[] gaps = new PriorityQueue[10];
@@ -76,5 +76,5 @@ public class Day09 extends DayTemplate {
         return answer;
     }
 
-    private record Gap(int start, int size) {}
+    record Gap(int start, int size) {}
 }

--- a/src/solutions/Day10.java
+++ b/src/solutions/Day10.java
@@ -5,7 +5,7 @@ import src.meta.DayTemplate;
 import java.util.*;
 
 public class Day10 extends DayTemplate {
-    private static final int[] DR = {-1, 1, 0, 0}, DC = {0, 0, -1, 1};
+    static final int[] DR = {-1, 1, 0, 0}, DC = {0, 0, -1, 1};
 
     public String solve(boolean part1, Scanner in) {
         List<String> lines = new ArrayList<>();
@@ -40,7 +40,7 @@ public class Day10 extends DayTemplate {
         return "" + (part1 ? scoreHeads(lines) : answer);
     }
 
-    private int scoreHeads(List<String> lines) {
+    int scoreHeads(List<String> lines) {
         int answer = 0;
         for (int r = 0; r < lines.size(); r++) {
             for (int c = 0; c < lines.get(0).length(); c++) {
@@ -52,7 +52,7 @@ public class Day10 extends DayTemplate {
         return answer;
     }
 
-    private int reaches(List<String> lines, int r, int c, boolean[][] seen) {
+    int reaches(List<String> lines, int r, int c, boolean[][] seen) {
         int h = lines.get(r).charAt(c) - '0';
         if (h == 9) {
             return seen[r][c] ? 0 : (seen[r][c] = true) ? 1 : 0;

--- a/src/solutions/Day10.java
+++ b/src/solutions/Day10.java
@@ -1,92 +1,70 @@
 package src.solutions;
 
-import java.util.Scanner;
-
 import src.meta.DayTemplate;
-import src.objects.Coordinate;
 
 import java.util.*;
 
-import static src.meta.Utils.*;
-
 public class Day10 extends DayTemplate {
+    private static final int[] DR = {-1, 1, 0, 0}, DC = {0, 0, -1, 1};
+
     public String solve(boolean part1, Scanner in) {
-        long answer = 0;
         List<String> lines = new ArrayList<>();
-        while(in.hasNext()){
-            String line = in.nextLine();
-            lines.add(line);
+        while (in.hasNextLine()) {
+            lines.add(in.nextLine());
         }
-        int[][] grid = buildGrid( lines, a -> a - '0');
-        List<Coordinate> trailheads = new ArrayList<>();
-        for(int i = 0; i < grid.length; i++){
-            for(int j = 0; j < grid[0].length; j++){
-                if(grid[i][j] == 0){
-                    trailheads.add(new Coordinate(i,j));
-                }
-            }
-        }
-
-        if(part1){
-            for(Coordinate c: trailheads){
-                answer += reachable(grid, c);
-            }
-        }
-        else{
-            answer = rating(grid);
-        }
-        return answer + "";
-    }
-
-    private int reachable(int[][] grid, Coordinate c){
-        Set<Coordinate> level = new HashSet<>();
-        level.add(c);
-        int counter = 0;
-        while(counter++ < 9){
-            Set<Coordinate> newLevel = new HashSet<>();
-            for(Coordinate l: level){
-                List<Coordinate> neighbors = getNeighbors(l.x, l.y, grid);
-                for(Coordinate n: neighbors){
-                    if(grid[n.x][n.y] == counter){
-                        newLevel.add(n);
-                    }
-                }
-            }
-            level = newLevel;
-        }
-        return level.size();
-    }
-
-    private long rating(int[][] grid){
+        int rows = lines.size(), cols = lines.get(0).length();
+        int[][] paths = new int[rows][cols];
         long answer = 0;
-        Set<Coordinate> peaks = new HashSet<>();
-        long[][] paths = new long[grid.length][grid[0].length];
-        for(int i = 0; i < grid.length; i++){
-            for(int j = 0; j < grid[0].length; j++){
-                if(grid[i][j] == 9){
-                    peaks.add(new Coordinate(i,j));
-                    paths[i][j] = 1;
-                }
-            }
-        }
-        int level = 9;
-        while(level-- > 0){
-            Set<Coordinate> newPeaks = new HashSet<>();
-            for(Coordinate l: peaks){
-                List<Coordinate> neighbors = getNeighbors(l.x, l.y, grid);
-                for(Coordinate n: neighbors){
-                    if(grid[n.x][n.y] == level){
-                        newPeaks.add(n);
-                        paths[n.x][n.y] += paths[l.x][l.y];
+        for (int h = 9; h >= 0; h--) {
+            for (int r = 0; r < rows; r++) {
+                for (int c = 0; c < cols; c++) {
+                    if (lines.get(r).charAt(c) - '0' != h) {
+                        continue;
+                    }
+                    if (h == 9) {
+                        paths[r][c] = 1;
+                    } else {
+                        for (int d = 0; d < 4; d++) {
+                            int nr = r + DR[d], nc = c + DC[d];
+                            if (nr >= 0 && nc >= 0 && nr < rows && nc < cols && lines.get(nr).charAt(nc) - '0' == h + 1) {
+                                paths[r][c] += part1 && h == 0 ? reaches(lines, nr, nc, new boolean[rows][cols]) : paths[nr][nc];
+                            }
+                        }
+                    }
+                    if (!part1 && h == 0) {
+                        answer += paths[r][c];
                     }
                 }
             }
-            peaks = newPeaks;
         }
+        return "" + (part1 ? scoreHeads(lines) : answer);
+    }
 
-        for(Coordinate c: peaks){
-            answer += paths[c.x][c.y];
+    private int scoreHeads(List<String> lines) {
+        int answer = 0;
+        for (int r = 0; r < lines.size(); r++) {
+            for (int c = 0; c < lines.get(0).length(); c++) {
+                if (lines.get(r).charAt(c) == '0') {
+                    answer += reaches(lines, r, c, new boolean[lines.size()][lines.get(0).length()]);
+                }
+            }
         }
         return answer;
+    }
+
+    private int reaches(List<String> lines, int r, int c, boolean[][] seen) {
+        int h = lines.get(r).charAt(c) - '0';
+        if (h == 9) {
+            return seen[r][c] ? 0 : (seen[r][c] = true) ? 1 : 0;
+        }
+        int total = 0;
+        for (int d = 0; d < 4; d++) {
+            int nr = r + DR[d], nc = c + DC[d];
+            if (nr >= 0 && nc >= 0 && nr < lines.size() && nc < lines.get(0).length()
+                    && lines.get(nr).charAt(nc) - '0' == h + 1) {
+                total += reaches(lines, nr, nc, seen);
+            }
+        }
+        return total;
     }
 }

--- a/src/solutions/Day11.java
+++ b/src/solutions/Day11.java
@@ -5,7 +5,7 @@ import src.meta.DayTemplate;
 import java.util.*;
 
 public class Day11 extends DayTemplate {
-    private final Map<String, Long> memo = new HashMap<>();
+    final Map<String, Long> memo = new HashMap<>();
 
     public String solve(boolean part1, Scanner in) {
         long answer = 0;
@@ -15,7 +15,7 @@ public class Day11 extends DayTemplate {
         return "" + answer;
     }
 
-    private long count(long stone, int blinks) {
+    long count(long stone, int blinks) {
         if (blinks == 0) {
             return 1;
         }

--- a/src/solutions/Day11.java
+++ b/src/solutions/Day11.java
@@ -2,160 +2,39 @@ package src.solutions;
 
 import src.meta.DayTemplate;
 
-import java.util.Scanner;
+import java.util.*;
 
 public class Day11 extends DayTemplate {
-
-    private static final long[] POW10 = {
-            1L,
-            10L,
-            100L,
-            1_000L,
-            10_000L,
-            100_000L,
-            1_000_000L,
-            10_000_000L,
-            100_000_000L,
-            1_000_000_000L,
-            10_000_000_000L,
-            100_000_000_000L,
-            1_000_000_000_000L,
-            10_000_000_000_000L,
-            100_000_000_000_000L,
-            1_000_000_000_000_000L,
-            10_000_000_000_000_000L,
-            100_000_000_000_000_000L,
-            1_000_000_000_000_000_000L
-    };
-
-    private long[] memoStones;
-    private int[] memoBlinks;
-    private long[] memoValues;
-    private boolean[] memoUsed;
-    private int memoSize;
-    private boolean memoFound;
+    private final Map<String, Long> memo = new HashMap<>();
 
     public String solve(boolean part1, Scanner in) {
-        int blinks = part1 ? 25 : 75;
         long answer = 0;
-        resetMemo();
-        String line = in.nextLine();
-        long stone = 0;
-        for (int i = 0; i <= line.length(); i++) {
-            if (i == line.length() || line.charAt(i) == ' ') {
-                answer += countStones(stone, blinks);
-                stone = 0;
-            } else {
-                stone = stone * 10 + line.charAt(i) - '0';
-            }
+        for (String s : in.nextLine().split(" ")) {
+            answer += count(Long.parseLong(s), part1 ? 25 : 75);
         }
-        return answer + "";
+        return "" + answer;
     }
 
-    private long countStones(long stone, int blinksLeft) {
-        if (blinksLeft == 0) {
+    private long count(long stone, int blinks) {
+        if (blinks == 0) {
             return 1;
         }
-
-        long cached = memoGet(stone, blinksLeft);
-        if (memoFound) {
-            return cached;
+        String key = stone + "," + blinks;
+        if (memo.containsKey(key)) {
+            return memo.get(key);
         }
-
-        long result;
+        long answer;
         if (stone == 0) {
-            result = countStones(1, blinksLeft - 1);
+            answer = count(1, blinks - 1);
         } else {
-            int digits = digits(stone);
-            if ((digits & 1) == 0) {
-                long divisor = POW10[digits / 2];
-                result = countStones(stone / divisor, blinksLeft - 1)
-                        + countStones(stone % divisor, blinksLeft - 1);
-            } else {
-                result = countStones(stone * 2024, blinksLeft - 1);
-            }
+            String s = "" + stone;
+            int half = s.length() / 2;
+            answer = s.length() % 2 == 0
+                    ? count(Long.parseLong(s.substring(0, half)), blinks - 1)
+                    + count(Long.parseLong(s.substring(half)), blinks - 1)
+                    : count(stone * 2024, blinks - 1);
         }
-
-        memoPut(stone, blinksLeft, result);
-        return result;
-    }
-
-    private void resetMemo() {
-        memoStones = new long[1 << 15];
-        memoBlinks = new int[memoStones.length];
-        memoValues = new long[memoStones.length];
-        memoUsed = new boolean[memoStones.length];
-        memoSize = 0;
-    }
-
-    private long memoGet(long stone, int blinksLeft) {
-        int index = memoIndex(stone, blinksLeft, memoStones.length);
-        while (memoUsed[index]) {
-            if (memoStones[index] == stone && memoBlinks[index] == blinksLeft) {
-                memoFound = true;
-                return memoValues[index];
-            }
-            index = (index + 1) & (memoStones.length - 1);
-        }
-        memoFound = false;
-        return 0;
-    }
-
-    private void memoPut(long stone, int blinksLeft, long value) {
-        if (memoSize * 2 >= memoStones.length) {
-            growMemo();
-        }
-        int index = memoIndex(stone, blinksLeft, memoStones.length);
-        while (memoUsed[index]) {
-            if (memoStones[index] == stone && memoBlinks[index] == blinksLeft) {
-                memoValues[index] = value;
-                return;
-            }
-            index = (index + 1) & (memoStones.length - 1);
-        }
-        memoUsed[index] = true;
-        memoStones[index] = stone;
-        memoBlinks[index] = blinksLeft;
-        memoValues[index] = value;
-        memoSize++;
-    }
-
-    private void growMemo() {
-        long[] oldStones = memoStones;
-        int[] oldBlinks = memoBlinks;
-        long[] oldValues = memoValues;
-        boolean[] oldUsed = memoUsed;
-        memoStones = new long[oldStones.length * 2];
-        memoBlinks = new int[memoStones.length];
-        memoValues = new long[memoStones.length];
-        memoUsed = new boolean[memoStones.length];
-        memoSize = 0;
-        for (int i = 0; i < oldStones.length; i++) {
-            if (oldUsed[i]) {
-                memoPut(oldStones[i], oldBlinks[i], oldValues[i]);
-            }
-        }
-    }
-
-    private int memoIndex(long stone, int blinksLeft, int length) {
-        long hash = stone ^ (stone >>> 32) ^ ((long) blinksLeft * 0x9E3779B97F4A7C15L);
-        hash ^= hash >>> 33;
-        hash *= 0xff51afd7ed558ccdL;
-        hash ^= hash >>> 33;
-        return (int) hash & (length - 1);
-    }
-
-    private int digits(long stone) {
-        int low = 0;
-        int high = POW10.length - 1;
-        while (low < high) {
-            int mid = (low + high + 1) >>> 1;
-            if (stone >= POW10[mid]) {
-                low = mid;
-            } else {
-                high = mid - 1;
-            }
-        }
-        return low + 1;
+        memo.put(key, answer);
+        return answer;
     }
 }

--- a/src/solutions/Day12.java
+++ b/src/solutions/Day12.java
@@ -5,10 +5,10 @@ import src.meta.DayTemplate;
 import java.util.*;
 
 public class Day12 extends DayTemplate {
-    private static final int[] DR = {-1, 1, 0, 0}, DC = {0, 0, -1, 1};
-    private int rows, cols;
-    private char[] grid;
-    private boolean[] seen, region;
+    static final int[] DR = {-1, 1, 0, 0}, DC = {0, 0, -1, 1};
+    int rows, cols;
+    char[] grid;
+    boolean[] seen, region;
 
     public String solve(boolean part1, Scanner in) {
         List<String> lines = new ArrayList<>();
@@ -57,7 +57,7 @@ public class Day12 extends DayTemplate {
         return "" + answer;
     }
 
-    private int sides(int[] cells, int n) {
+    int sides(int[] cells, int n) {
         int total = 0;
         for (int i = 0; i < n; i++) {
             int r = cells[i] / cols, c = cells[i] % cols;
@@ -73,11 +73,11 @@ public class Day12 extends DayTemplate {
         return total;
     }
 
-    private boolean has(int r, int c) {
+    boolean has(int r, int c) {
         return r >= 0 && c >= 0 && r < rows && c < cols && region[id(r, c)];
     }
 
-    private int id(int r, int c) {
+    int id(int r, int c) {
         return r * cols + c;
     }
 }

--- a/src/solutions/Day12.java
+++ b/src/solutions/Day12.java
@@ -2,110 +2,82 @@ package src.solutions;
 
 import src.meta.DayTemplate;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Scanner;
+import java.util.*;
 
 public class Day12 extends DayTemplate {
-
-    private static final int[] DR = {-1, 1, 0, 0};
-    private static final int[] DC = {0, 0, -1, 1};
+    private static final int[] DR = {-1, 1, 0, 0}, DC = {0, 0, -1, 1};
+    private int rows, cols;
+    private char[] grid;
+    private boolean[] seen, region;
 
     public String solve(boolean part1, Scanner in) {
         List<String> lines = new ArrayList<>();
         while (in.hasNextLine()) {
             lines.add(in.nextLine());
         }
-
-        int rows = lines.size();
-        int cols = lines.get(0).length();
-        char[] grid = new char[rows * cols];
-        for (int row = 0; row < rows; row++) {
-            String line = lines.get(row);
-            for (int col = 0; col < cols; col++) {
-                grid[row * cols + col] = line.charAt(col);
+        rows = lines.size();
+        cols = lines.get(0).length();
+        grid = new char[rows * cols];
+        for (int r = 0; r < rows; r++) {
+            for (int c = 0; c < cols; c++) {
+                grid[id(r, c)] = lines.get(r).charAt(c);
             }
         }
-
-        boolean[] visited = new boolean[grid.length];
-        boolean[] inRegion = new boolean[grid.length];
-        int[] queue = new int[grid.length];
-        int[] region = new int[grid.length];
+        seen = new boolean[grid.length];
+        region = new boolean[grid.length];
+        int[] q = new int[grid.length], cells = new int[grid.length];
         long answer = 0;
-
         for (int start = 0; start < grid.length; start++) {
-            if (visited[start]) {
+            if (seen[start]) {
                 continue;
             }
-
+            int head = 0, tail = 1, n = 0, perimeter = 0;
             char crop = grid[start];
-            int head = 0;
-            int tail = 0;
-            int regionSize = 0;
-            int perimeter = 0;
-            visited[start] = true;
-            queue[tail++] = start;
-
+            q[0] = start;
+            seen[start] = true;
             while (head < tail) {
-                int current = queue[head++];
-                region[regionSize++] = current;
-                inRegion[current] = true;
-                int row = current / cols;
-                int col = current % cols;
-
-                for (int dir = 0; dir < 4; dir++) {
-                    int nextRow = row + DR[dir];
-                    int nextCol = col + DC[dir];
-                    if (nextRow < 0 || nextCol < 0 || nextRow >= rows || nextCol >= cols) {
+                int p = q[head++], r = p / cols, c = p % cols;
+                cells[n++] = p;
+                region[p] = true;
+                for (int d = 0; d < 4; d++) {
+                    int nr = r + DR[d], nc = c + DC[d];
+                    if (nr < 0 || nc < 0 || nr >= rows || nc >= cols || grid[id(nr, nc)] != crop) {
                         perimeter++;
-                        continue;
-                    }
-
-                    int next = nextRow * cols + nextCol;
-                    if (grid[next] != crop) {
-                        perimeter++;
-                    } else if (!visited[next]) {
-                        visited[next] = true;
-                        queue[tail++] = next;
+                    } else if (!seen[id(nr, nc)]) {
+                        seen[id(nr, nc)] = true;
+                        q[tail++] = id(nr, nc);
                     }
                 }
             }
-
-            long price = part1 ? perimeter : countSides(region, regionSize, inRegion, rows, cols);
-            answer += regionSize * price;
-            for (int i = 0; i < regionSize; i++) {
-                inRegion[region[i]] = false;
+            answer += (long) n * (part1 ? perimeter : sides(cells, n));
+            for (int i = 0; i < n; i++) {
+                region[cells[i]] = false;
             }
         }
-        return answer + "";
+        return "" + answer;
     }
 
-    private int countSides(int[] region, int regionSize, boolean[] inRegion, int rows, int cols) {
-        int sides = 0;
-        for (int i = 0; i < regionSize; i++) {
-            int current = region[i];
-            int row = current / cols;
-            int col = current % cols;
-
-            sides += countCorner(row, col, -1, -1, inRegion, rows, cols);
-            sides += countCorner(row, col, -1, 1, inRegion, rows, cols);
-            sides += countCorner(row, col, 1, -1, inRegion, rows, cols);
-            sides += countCorner(row, col, 1, 1, inRegion, rows, cols);
+    private int sides(int[] cells, int n) {
+        int total = 0;
+        for (int i = 0; i < n; i++) {
+            int r = cells[i] / cols, c = cells[i] % cols;
+            for (int dr = -1; dr <= 1; dr += 2) {
+                for (int dc = -1; dc <= 1; dc += 2) {
+                    boolean a = has(r + dr, c), b = has(r, c + dc);
+                    if ((!a && !b) || (a && b && !has(r + dr, c + dc))) {
+                        total++;
+                    }
+                }
+            }
         }
-        return sides;
+        return total;
     }
 
-    private int countCorner(int row, int col, int rowStep, int colStep, boolean[] inRegion, int rows, int cols) {
-        boolean rowNeighbor = contains(row + rowStep, col, inRegion, rows, cols);
-        boolean colNeighbor = contains(row, col + colStep, inRegion, rows, cols);
-        if (!rowNeighbor && !colNeighbor) {
-            return 1;
-        }
-        boolean diagonal = contains(row + rowStep, col + colStep, inRegion, rows, cols);
-        return rowNeighbor && colNeighbor && !diagonal ? 1 : 0;
+    private boolean has(int r, int c) {
+        return r >= 0 && c >= 0 && r < rows && c < cols && region[id(r, c)];
     }
 
-    private boolean contains(int row, int col, boolean[] inRegion, int rows, int cols) {
-        return row >= 0 && col >= 0 && row < rows && col < cols && inRegion[row * cols + col];
+    private int id(int r, int c) {
+        return r * cols + c;
     }
 }

--- a/src/solutions/Day13.java
+++ b/src/solutions/Day13.java
@@ -22,7 +22,7 @@ public class Day13 extends DayTemplate {
         return answer+"";
     }
 
-    private long oneCycle(long x1, long y1, long x2, long y2, long x3, long y3){
+    long oneCycle(long x1, long y1, long x2, long y2, long x3, long y3){
         if(y3%gcd(y1,y2) != 0 || x3%gcd(x1,x2) !=0){
             return 0;
         }
@@ -60,7 +60,7 @@ public class Day13 extends DayTemplate {
         return a * 3 + b;
     }
 
-    private long helper(String[] lines, boolean part1){
+    long helper(String[] lines, boolean part1){
         String[] first =  lines[0].split("[,+]");
         String[] second = lines[1].split("[,+]");
         String[] third = lines[2].split("[,=]");

--- a/src/solutions/Day14.java
+++ b/src/solutions/Day14.java
@@ -1,141 +1,54 @@
 package src.solutions;
+
 import src.meta.DayTemplate;
 
 import java.util.*;
 
 public class Day14 extends DayTemplate {
     public String solve(boolean part1, Scanner in) {
-        long answer = 0;
-        List<Robot> robots = new ArrayList<>();
-        while(in.hasNext()){
-            String line = in.nextLine();
-            String[] parts = line.split(" |,|=");
-            robots.add(new Robot(Integer.parseInt(parts[1]),Integer.parseInt(parts[2]), Integer.parseInt(parts[4]), Integer.parseInt(parts[5])));
+        List<int[]> robots = new ArrayList<>();
+        while (in.hasNextLine()) {
+            String[] p = in.nextLine().split(" |,|=");
+            robots.add(new int[]{Integer.parseInt(p[1]), Integer.parseInt(p[2]), Integer.parseInt(p[4]), Integer.parseInt(p[5])});
         }
-
-        if(part1){
-            int xlimit = 101;
-            int ylimit = 103;
-            for(Robot robot: robots){
-                robot.updateBatch(xlimit, ylimit, 100);
-            }
-
-            int[] quadrants = new int[]{0,0,0,0};
-            for(Robot robot: robots){
-                if(robot.x%xlimit > (xlimit - 1)/2){
-                    if(robot.y%ylimit > (ylimit - 1)/2){
-                        quadrants[0]++;
-                    }
-                    if(robot.y%ylimit < (ylimit - 1)/2){
-                        quadrants[1]++;
-                    }
-                }
-                if(robot.x%xlimit < (xlimit - 1)/2){
-                    if(robot.y%ylimit > (ylimit - 1)/2){
-                        quadrants[2]++;
-                    }
-                    if(robot.y%ylimit < (ylimit - 1)/2){
-                        quadrants[3]++;
-                    }
+        if (part1) {
+            int[] q = new int[4];
+            for (int[] r : robots) {
+                move(r, 100);
+                if (r[0] != 50 && r[1] != 51) {
+                    q[(r[0] < 50 ? 0 : 1) + (r[1] < 51 ? 0 : 2)]++;
                 }
             }
-            answer = (long)quadrants[0] * quadrants[1]* quadrants[2] * quadrants[3];
+            return "" + (long) q[0] * q[1] * q[2] * q[3];
         }
-        else{
-            int xlimit = 101;
-            int ylimit = 103;
-            int counter = 1;
-            int increment = 1;
-            int[] xCounts = new int[xlimit];
-            int[] yCounts = new int[ylimit];
-            while(counter < 103 * 101){
-                for(Robot robot: robots){
-                    robot.updateBatch(xlimit, ylimit, increment);
-                }
-                boolean boxX = boxX(robots, xCounts);
-                boolean boxY = boxY(robots, yCounts);
-                if(boxX && boxY){
-                    return counter + "";
-                }
-                if(boxX){
-                    increment = 101;
-                }
-                counter += increment;
-
+        int[] xs = new int[101], ys = new int[103];
+        for (int time = 1, jump = 1; time < 10403; time += jump) {
+            for (int[] r : robots) {
+                move(r, jump);
+            }
+            boolean bx = crowded(robots, xs, 0), by = crowded(robots, ys, 1);
+            if (bx && by) {
+                return "" + time;
+            }
+            if (bx) {
+                jump = 101;
             }
         }
-        return answer + "";
+        return "0";
     }
 
-//    private boolean box(List<Robot> robots){
-//        HashMap<Integer, Integer> mapX = new HashMap<>();
-//        HashMap<Integer, Integer> mapY = new HashMap<>();
-//        for(Robot robot: robots){
-//            mapX.merge(robot.x, 1, Integer::sum);
-//            mapY.merge(robot.y, 1, Integer::sum);
-//        }
-//
-//        boolean xbox = false;
-//        boolean ybox = false;
-//
-//        for(int key: mapX.keySet()){
-//            if(mapX.get(key) > 30){
-//                xbox = true;
-//            }
-//        }
-//        for(int key: mapY.keySet()){
-//            if(mapY.get(key) > 30){
-//                ybox = true;
-//            }
-//        }
-//        return xbox && ybox;
-//    }
+    private void move(int[] r, int n) {
+        r[0] = ((r[0] + r[2] * n) % 101 + 101) % 101;
+        r[1] = ((r[1] + r[3] * n) % 103 + 103) % 103;
+    }
 
-    private boolean boxX(List<Robot> robots, int[] counts){
-        Arrays.fill(counts, 0);
-        for(Robot robot: robots){
-            if(++counts[robot.x] > 30){
+    private boolean crowded(List<int[]> robots, int[] count, int axis) {
+        Arrays.fill(count, 0);
+        for (int[] r : robots) {
+            if (++count[r[axis]] > 30) {
                 return true;
             }
         }
         return false;
-    }
-
-    private boolean boxY(List<Robot> robots, int[] counts){
-        Arrays.fill(counts, 0);
-        for(Robot robot: robots){
-            if(++counts[robot.y] > 30){
-                return true;
-            }
-        }
-        return false;
-    }
-}
-
-class Robot{
-    int x;
-    int y;
-    int vx;
-    int vy;
-
-    public Robot(int x, int y, int vx, int vy){
-        this.x = x;
-        this.y = y;
-        this.vx = vx;
-        this.vy = vy;
-    }
-
-    public void update(int xlimit, int ylimit){
-        x += vx;
-        y += vy;
-        x = (x%xlimit + xlimit)%xlimit;
-        y = (y%ylimit + ylimit)%ylimit;
-    }
-
-    public void updateBatch(int xlimit, int ylimit, int numUpdate){
-        x += vx * numUpdate;
-        y += vy * numUpdate;
-        x = (x%xlimit + xlimit)%xlimit;
-        y = (y%ylimit + ylimit)%ylimit;
     }
 }

--- a/src/solutions/Day14.java
+++ b/src/solutions/Day14.java
@@ -37,12 +37,12 @@ public class Day14 extends DayTemplate {
         return "0";
     }
 
-    private void move(int[] r, int n) {
+    void move(int[] r, int n) {
         r[0] = ((r[0] + r[2] * n) % 101 + 101) % 101;
         r[1] = ((r[1] + r[3] * n) % 103 + 103) % 103;
     }
 
-    private boolean crowded(List<int[]> robots, int[] count, int axis) {
+    boolean crowded(List<int[]> robots, int[] count, int axis) {
         Arrays.fill(count, 0);
         for (int[] r : robots) {
             if (++count[r[axis]] > 30) {

--- a/src/solutions/Day15.java
+++ b/src/solutions/Day15.java
@@ -5,9 +5,9 @@ import src.meta.DayTemplate;
 import java.util.*;
 
 public class Day15 extends DayTemplate {
-    private static final int[] DR = {-1, 1, 0, 0}, DC = {0, 0, -1, 1};
-    private char[][] grid;
-    private int r, c;
+    static final int[] DR = {-1, 1, 0, 0}, DC = {0, 0, -1, 1};
+    char[][] grid;
+    int r, c;
 
     public String solve(boolean part1, Scanner in) {
         List<String> map = new ArrayList<>();
@@ -47,7 +47,7 @@ public class Day15 extends DayTemplate {
         return "" + answer;
     }
 
-    private void step(int d, boolean part1) {
+    void step(int d, boolean part1) {
         int nr = r + DR[d], nc = c + DC[d];
         if (grid[nr][nc] == '#') {
             return;
@@ -76,7 +76,7 @@ public class Day15 extends DayTemplate {
         }
     }
 
-    private boolean pushVertical(int d) {
+    boolean pushVertical(int d) {
         List<Set<Integer>> layers = new ArrayList<>();
         layers.add(boxes(r + DR[d], c));
         for (int row = r + DR[d];;) {
@@ -105,7 +105,7 @@ public class Day15 extends DayTemplate {
         return true;
     }
 
-    private Set<Integer> boxes(int row, int col) {
+    Set<Integer> boxes(int row, int col) {
         Set<Integer> s = new HashSet<>();
         s.add(col);
         s.add(grid[row][col] == '[' ? col + 1 : col - 1);

--- a/src/solutions/Day15.java
+++ b/src/solutions/Day15.java
@@ -1,172 +1,114 @@
 package src.solutions;
 
 import src.meta.DayTemplate;
-import src.objects.Coordinate;
 
 import java.util.*;
 
 public class Day15 extends DayTemplate {
-
-    int[]xs = new int[]{1,-1,0,0};
-    int[]ys = new int[]{0,0,1,-1};
+    private static final int[] DR = {-1, 1, 0, 0}, DC = {0, 0, -1, 1};
+    private char[][] grid;
+    private int r, c;
 
     public String solve(boolean part1, Scanner in) {
-        long answer = 0;
-        List<String> lines = new ArrayList<>();
-        List<String> movements = new ArrayList<>();
-        boolean movement = false;
-        while (in.hasNext()) {
+        List<String> map = new ArrayList<>();
+        StringBuilder moves = new StringBuilder();
+        for (boolean readingMoves = false; in.hasNextLine();) {
             String line = in.nextLine();
-            if(line.isEmpty()){
-                movement = true;
-                continue;
-            }
-            if(!movement){
-                lines.add(line);
-            }
-            else{
-                movements.add(line);
+            if (line.isEmpty()) {
+                readingMoves = true;
+            } else if (readingMoves) {
+                moves.append(line);
+            } else {
+                map.add(part1 ? line : line.replace("#", "##").replace(".", "..").replace("O", "[]").replace("@", "@."));
             }
         }
-        if(!part1){
-            lines = convert(lines);
-        }
-
-        int[][] grid = new int[lines.size()][lines.get(0).length()];
-        Coordinate robot = new Coordinate(0,0);
-        Map<Character, Integer> mapping = Map.of('#',1000,'.',1,'O',2,'[',3,']',4);
-        for(int i = 0; i < grid.length; i++){
-            for(int j = 0; j < grid[0].length; j++){
-                char c = lines.get(i).charAt(j);
-                if(c == '@'){
-                    robot = new Coordinate(i,j);
-                    grid[i][j] = 1;
-                }
-                else{
-                    grid[i][j] = mapping.get(c);
+        grid = new char[map.size()][];
+        for (int i = 0; i < map.size(); i++) {
+            grid[i] = map.get(i).toCharArray();
+            for (int j = 0; j < grid[i].length; j++) {
+                if (grid[i][j] == '@') {
+                    r = i;
+                    c = j;
+                    grid[i][j] = '.';
                 }
             }
         }
-
-        StringBuilder allMovements = new StringBuilder();
-        for(String move: movements){
-            allMovements.append(move);
+        for (char move : moves.toString().toCharArray()) {
+            step("^v<>".indexOf(move), part1);
         }
-        for(char c: allMovements.toString().toCharArray()){
-            oneCycle(c, robot, grid, part1);
-        }
-        for(int i = 0; i < grid.length; i++) {
-            for (int j = 0; j < grid[0].length; j++) {
-                if (grid[i][j] == 2 || grid[i][j] == 3) {
+        long answer = 0;
+        for (int i = 0; i < grid.length; i++) {
+            for (int j = 0; j < grid[i].length; j++) {
+                if (grid[i][j] == 'O' || grid[i][j] == '[') {
                     answer += 100L * i + j;
                 }
             }
         }
-        return answer + "";
+        return "" + answer;
     }
 
-    private static List<String> convert(List<String> lines) {
-        List<String> newLines = new ArrayList<>();
-        Map<Character, String> mapping = Map.of('#',"##", '.',"..",'O',"[]",'@',"@.");
-        for (String line : lines) {
-            StringBuilder newLine = new StringBuilder();
-            for (char c : line.toCharArray()) {
-                newLine.append(mapping.get(c));
-            }
-            newLines.add(newLine.toString());
+    private void step(int d, boolean part1) {
+        int nr = r + DR[d], nc = c + DC[d];
+        if (grid[nr][nc] == '#') {
+            return;
         }
-        return newLines;
+        if (grid[nr][nc] == '.') {
+            r = nr;
+            c = nc;
+        } else if (part1 || DC[d] != 0) {
+            int er = nr, ec = nc;
+            while (grid[er][ec] != '#' && grid[er][ec] != '.') {
+                er += DR[d];
+                ec += DC[d];
+            }
+            if (grid[er][ec] == '.') {
+                while (er != nr || ec != nc) {
+                    grid[er][ec] = grid[er - DR[d]][ec - DC[d]];
+                    er -= DR[d];
+                    ec -= DC[d];
+                }
+                grid[nr][nc] = '.';
+                r = nr;
+                c = nc;
+            }
+        } else if (pushVertical(d)) {
+            r = nr;
+        }
     }
 
-    private void oneCycle(char c, Coordinate robot, int[][] grid, boolean part1){
-        int direction = -1;
-        if(c == '^'){
-            direction = 1;
-        }
-        if(c == 'v'){
-            direction = 0;
-        }
-        if(c == '>'){
-            direction = 2;
-        }
-        if(c == '<'){
-            direction = 3;
-        }
-        Coordinate goal = new Coordinate(robot.x + xs[direction], robot.y + ys[direction]);
-        if(grid[goal.x][goal.y] == 1){
-            robot.x = goal.x;
-            robot.y = goal.y;
-            return;
-        }
-        if(grid[goal.x][goal.y] == 1000){
-            return;
-        }
-        if(direction == 2 || direction == 3 || part1){
-            boolean someEmpty = false;
-            Coordinate firstEmpty = new Coordinate(1,-1);
-            int counter = 0;
-            while(true){
-                counter++;
-                goal = new Coordinate(goal.x + xs[direction], goal.y + ys[direction]);
-                if(grid[goal.x][goal.y] == 1000){
-                    break;
+    private boolean pushVertical(int d) {
+        List<Set<Integer>> layers = new ArrayList<>();
+        layers.add(boxes(r + DR[d], c));
+        for (int row = r + DR[d];;) {
+            Set<Integer> next = new HashSet<>();
+            row += DR[d];
+            for (int col : layers.get(layers.size() - 1)) {
+                if (grid[row][col] == '#') {
+                    return false;
                 }
-                if(grid[goal.x][goal.y] == 1){
-                    someEmpty = true;
-                    firstEmpty = new Coordinate(goal.x, goal.y);
-                    break;
+                if (grid[row][col] == '[' || grid[row][col] == ']') {
+                    next.addAll(boxes(row, col));
                 }
             }
-            if(someEmpty){
-                while(counter-- > 0){
-                    grid[firstEmpty.x][firstEmpty.y] = grid[firstEmpty.x - xs[direction]][firstEmpty.y - ys[direction]];
-                    firstEmpty.x -= xs[direction];
-                    firstEmpty.y -= ys[direction];
-                }
-                robot.x += xs[direction];
-                robot.y += ys[direction];
-                grid[robot.x][robot.y] = 1;
+            if (next.isEmpty()) {
+                break;
+            }
+            layers.add(next);
+        }
+        for (int i = layers.size() - 1; i >= 0; i--) {
+            int row = r + (i + 1) * DR[d];
+            for (int col : layers.get(i)) {
+                grid[row + DR[d]][col] = grid[row][col];
+                grid[row][col] = '.';
             }
         }
-        else{
-            List<Set<Integer>> indices = new ArrayList<>();
-            indices.add(new HashSet<>());
-            indices.get(0).add(robot.y);
-            boolean allEmpty = false;
-            int level = robot.x;
-            while(!allEmpty) {
-                Set<Integer> nextIndices = new HashSet<>();
-                level += xs[direction];
-                allEmpty = true;
-                for (int index : indices.get(indices.size() - 1)) {
-                    if (grid[level][index] == 1000) {
-                        return;
-                    }
-                    if (grid[level][index] != 1) {
-                        allEmpty = false;
-                    }
-                    if (grid[level][index] == 3) {
-                        nextIndices.add(index + 1);
-                        nextIndices.add(index);
-                    }
-                    if (grid[level][index] == 4) {
-                        nextIndices.add(index - 1);
-                        nextIndices.add(index);
-                    }
-                }
-                if(!allEmpty){
-                    indices.add(nextIndices);
-                }
-            }
-            for(int i = indices.size() - 1; i > 0; i--) {
-                Set<Integer> indicesLayer = indices.get(i);
-                for(int index: indicesLayer){
-                    grid[robot.x + ((i + 1) * xs[direction])][index] = grid[robot.x + (i * xs[direction])][index];
-                    grid[robot.x + (i * xs[direction])][index] = 1;
-                }
-            }
-            robot.x += xs[direction];
-            robot.y += ys[direction];
-        }
+        return true;
+    }
+
+    private Set<Integer> boxes(int row, int col) {
+        Set<Integer> s = new HashSet<>();
+        s.add(col);
+        s.add(grid[row][col] == '[' ? col + 1 : col - 1);
+        return s;
     }
 }

--- a/src/solutions/Day16.java
+++ b/src/solutions/Day16.java
@@ -2,223 +2,97 @@ package src.solutions;
 
 import src.meta.DayTemplate;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Scanner;
+import java.util.*;
 
 public class Day16 extends DayTemplate {
-
-    private static final int INF = Integer.MAX_VALUE / 4;
-    private static final int TURN_COST = 1000;
-    private static final int[] DR = {0, 1, 0, -1};
-    private static final int[] DC = {1, 0, -1, 0};
-
-    private int rows;
-    private int cols;
-    private boolean[] walls;
+    private static final int[] DR = {0, 1, 0, -1}, DC = {1, 0, -1, 0};
+    private int rows, cols, start, end;
+    private char[][] grid;
 
     public String solve(boolean part1, Scanner in) {
         List<String> lines = new ArrayList<>();
         while (in.hasNextLine()) {
             lines.add(in.nextLine());
         }
-
         rows = lines.size();
         cols = lines.get(0).length();
-        walls = new boolean[rows * cols];
-        int start = -1;
-        int exit = -1;
-        for (int row = 0; row < rows; row++) {
-            String line = lines.get(row);
-            for (int col = 0; col < cols; col++) {
-                char c = line.charAt(col);
-                int cell = row * cols + col;
-                if (c == '#') {
-                    walls[cell] = true;
-                } else if (c == 'S') {
-                    start = cell;
-                } else if (c == 'E') {
-                    exit = cell;
+        grid = new char[rows][];
+        for (int r = 0; r < rows; r++) {
+            grid[r] = lines.get(r).toCharArray();
+            for (int c = 0; c < cols; c++) {
+                if (grid[r][c] == 'S') {
+                    start = cell(r, c);
+                } else if (grid[r][c] == 'E') {
+                    end = cell(r, c);
                 }
             }
         }
-
-        int[] fromStart = distancesFromStart(start);
-        int bestScore = bestExitScore(fromStart, exit);
+        int[] fromStart = dijkstra(false), toEnd = dijkstra(true);
+        int best = Integer.MAX_VALUE / 4;
+        for (int d = 0; d < 4; d++) {
+            best = Math.min(best, fromStart[state(end, d)]);
+        }
         if (part1) {
-            return bestScore + "";
+            return "" + best;
         }
-
-        int[] toExit = distancesToExit(exit);
-        return countBestPathTiles(fromStart, toExit, bestScore) + "";
-    }
-
-    private int[] distancesFromStart(int start) {
-        int[] distances = emptyDistances();
-        LongHeap heap = new LongHeap();
-        distances[state(start, 0)] = 0;
-        heap.add(0, state(start, 0));
-        while (!heap.isEmpty()) {
-            long entry = heap.poll();
-            int score = score(entry);
-            int state = state(entry);
-            if (score != distances[state]) {
-                continue;
-            }
-            addMove(distances, heap, state, score, true);
-            addTurn(distances, heap, state, score, (direction(state) + 1) & 3);
-            addTurn(distances, heap, state, score, (direction(state) + 3) & 3);
-        }
-        return distances;
-    }
-
-    private int[] distancesToExit(int exit) {
-        int[] distances = emptyDistances();
-        LongHeap heap = new LongHeap();
-        for (int direction = 0; direction < 4; direction++) {
-            int state = state(exit, direction);
-            distances[state] = 0;
-            heap.add(0, state);
-        }
-        while (!heap.isEmpty()) {
-            long entry = heap.poll();
-            int score = score(entry);
-            int state = state(entry);
-            if (score != distances[state]) {
-                continue;
-            }
-            addMove(distances, heap, state, score, false);
-            addTurn(distances, heap, state, score, (direction(state) + 1) & 3);
-            addTurn(distances, heap, state, score, (direction(state) + 3) & 3);
-        }
-        return distances;
-    }
-
-    private int[] emptyDistances() {
-        int[] distances = new int[rows * cols * 4];
-        Arrays.fill(distances, INF);
-        return distances;
-    }
-
-    private void addMove(int[] distances, LongHeap heap, int state, int score, boolean forward) {
-        int direction = direction(state);
-        int cell = cell(state);
-        int row = cell / cols;
-        int col = cell % cols;
-        int nextRow = forward ? row + DR[direction] : row - DR[direction];
-        int nextCol = forward ? col + DC[direction] : col - DC[direction];
-        if (nextRow < 0 || nextCol < 0 || nextRow >= rows || nextCol >= cols) {
-            return;
-        }
-        int nextCell = nextRow * cols + nextCol;
-        if (!walls[nextCell]) {
-            updateDistance(distances, heap, score + 1, state(nextCell, direction));
-        }
-    }
-
-    private void addTurn(int[] distances, LongHeap heap, int state, int score, int newDirection) {
-        updateDistance(distances, heap, score + TURN_COST, state(cell(state), newDirection));
-    }
-
-    private void updateDistance(int[] distances, LongHeap heap, int score, int state) {
-        if (score < distances[state]) {
-            distances[state] = score;
-            heap.add(score, state);
-        }
-    }
-
-    private int bestExitScore(int[] distances, int exit) {
-        int best = INF;
-        for (int direction = 0; direction < 4; direction++) {
-            best = Math.min(best, distances[state(exit, direction)]);
-        }
-        return best;
-    }
-
-    private long countBestPathTiles(int[] fromStart, int[] toExit, int bestScore) {
-        long total = 0;
-        for (int cell = 0; cell < walls.length; cell++) {
-            if (walls[cell]) {
-                continue;
-            }
-            for (int direction = 0; direction < 4; direction++) {
-                int state = state(cell, direction);
-                if (fromStart[state] + toExit[state] == bestScore) {
-                    total++;
-                    break;
+        int tiles = 0;
+        for (int r = 0; r < rows; r++) {
+            for (int c = 0; c < cols; c++) {
+                if (grid[r][c] == '#') {
+                    continue;
+                }
+                for (int d = 0; d < 4; d++) {
+                    int s = state(cell(r, c), d);
+                    if (fromStart[s] + toEnd[s] == best) {
+                        tiles++;
+                        break;
+                    }
                 }
             }
         }
-        return total;
+        return "" + tiles;
+    }
+
+    private int[] dijkstra(boolean reverse) {
+        int inf = Integer.MAX_VALUE / 4;
+        int[] dist = new int[rows * cols * 4];
+        Arrays.fill(dist, inf);
+        PriorityQueue<int[]> q = new PriorityQueue<>(Comparator.comparingInt(a -> a[0]));
+        if (reverse) {
+            for (int d = 0; d < 4; d++) {
+                add(q, dist, 0, state(end, d));
+            }
+        } else {
+            add(q, dist, 0, state(start, 0));
+        }
+        while (!q.isEmpty()) {
+            int[] x = q.poll();
+            int score = x[0], s = x[1], d = s & 3, p = s >> 2, r = p / cols, c = p % cols;
+            if (score != dist[s]) {
+                continue;
+            }
+            add(q, dist, score + 1000, state(p, (d + 1) & 3));
+            add(q, dist, score + 1000, state(p, (d + 3) & 3));
+            int nr = r + (reverse ? -DR[d] : DR[d]), nc = c + (reverse ? -DC[d] : DC[d]);
+            if (nr >= 0 && nc >= 0 && nr < rows && nc < cols && grid[nr][nc] != '#') {
+                add(q, dist, score + 1, state(cell(nr, nc), d));
+            }
+        }
+        return dist;
+    }
+
+    private void add(PriorityQueue<int[]> q, int[] dist, int score, int state) {
+        if (score < dist[state]) {
+            dist[state] = score;
+            q.add(new int[]{score, state});
+        }
+    }
+
+    private int cell(int r, int c) {
+        return r * cols + c;
     }
 
     private int state(int cell, int direction) {
-        return (cell << 2) | direction;
-    }
-
-    private int cell(int state) {
-        return state >> 2;
-    }
-
-    private int direction(int state) {
-        return state & 3;
-    }
-
-    private int score(long entry) {
-        return (int) (entry >>> 32);
-    }
-
-    private int state(long entry) {
-        return (int) entry;
-    }
-
-    private static final class LongHeap {
-        private long[] heap = new long[1024];
-        private int size;
-
-        boolean isEmpty() {
-            return size == 0;
-        }
-
-        void add(int score, int state) {
-            if (size == heap.length) {
-                heap = Arrays.copyOf(heap, heap.length * 2);
-            }
-            long entry = ((long) score << 32) | (state & 0xffffffffL);
-            int index = size++;
-            while (index > 0) {
-                int parent = (index - 1) >>> 1;
-                if (heap[parent] <= entry) {
-                    break;
-                }
-                heap[index] = heap[parent];
-                index = parent;
-            }
-            heap[index] = entry;
-        }
-
-        long poll() {
-            long result = heap[0];
-            long replacement = heap[--size];
-            int index = 0;
-            while (true) {
-                int child = index * 2 + 1;
-                if (child >= size) {
-                    break;
-                }
-                int right = child + 1;
-                if (right < size && heap[right] < heap[child]) {
-                    child = right;
-                }
-                if (heap[child] >= replacement) {
-                    break;
-                }
-                heap[index] = heap[child];
-                index = child;
-            }
-            heap[index] = replacement;
-            return result;
-        }
+        return cell * 4 + direction;
     }
 }

--- a/src/solutions/Day16.java
+++ b/src/solutions/Day16.java
@@ -5,9 +5,9 @@ import src.meta.DayTemplate;
 import java.util.*;
 
 public class Day16 extends DayTemplate {
-    private static final int[] DR = {0, 1, 0, -1}, DC = {1, 0, -1, 0};
-    private int rows, cols, start, end;
-    private char[][] grid;
+    static final int[] DR = {0, 1, 0, -1}, DC = {1, 0, -1, 0};
+    int rows, cols, start, end;
+    char[][] grid;
 
     public String solve(boolean part1, Scanner in) {
         List<String> lines = new ArrayList<>();
@@ -53,7 +53,7 @@ public class Day16 extends DayTemplate {
         return "" + tiles;
     }
 
-    private int[] dijkstra(boolean reverse) {
+    int[] dijkstra(boolean reverse) {
         int inf = Integer.MAX_VALUE / 4;
         int[] dist = new int[rows * cols * 4];
         Arrays.fill(dist, inf);
@@ -81,18 +81,18 @@ public class Day16 extends DayTemplate {
         return dist;
     }
 
-    private void add(PriorityQueue<int[]> q, int[] dist, int score, int state) {
+    void add(PriorityQueue<int[]> q, int[] dist, int score, int state) {
         if (score < dist[state]) {
             dist[state] = score;
             q.add(new int[]{score, state});
         }
     }
 
-    private int cell(int r, int c) {
+    int cell(int r, int c) {
         return r * cols + c;
     }
 
-    private int state(int cell, int direction) {
+    int state(int cell, int direction) {
         return cell * 4 + direction;
     }
 }

--- a/src/solutions/Day17.java
+++ b/src/solutions/Day17.java
@@ -1,100 +1,72 @@
 package src.solutions;
 
 import src.meta.DayTemplate;
+
 import java.util.*;
 
 public class Day17 extends DayTemplate {
-
     public String solve(boolean part1, Scanner in) {
-        long registerA = 15401536L;
+        long a = 15401536;
         in.nextLine();
-        long registerB = Long.parseLong(in.nextLine().split(" ")[2]);
-        long registerC = Long.parseLong(in.nextLine().split(" ")[2]);
+        long b = Long.parseLong(in.nextLine().split(" ")[2]);
+        long c = Long.parseLong(in.nextLine().split(" ")[2]);
         in.nextLine();
-        String stringProgram = in.nextLine().split(" ")[1];
-        List<Integer> program = new ArrayList<>();
-        for(String s: stringProgram.split(",")){
-            program.add(Integer.parseInt(s));
+        int[] p = Arrays.stream(in.nextLine().split(" ")[1].split(",")).mapToInt(Integer::parseInt).toArray();
+        if (part1) {
+            return run(p, a, b, c).toString().replace(" ", "");
         }
-        if(part1){
-            List<Integer> result = run(program, registerA, registerB, registerC);
-            return (result + "").replace(" ", "");
-        }
-        List<Long> possibilities = new ArrayList<>(List.of(0L));
-        for(int outputStart = program.size() - 1; outputStart >= 0; outputStart--){
-            List<Integer> targetSuffix = program.subList(outputStart, program.size());
-            List<Long> newPossibilities = new ArrayList<>();
-            for(long possibility: possibilities){
-                // This program emits once per base-8 digit of A.  Build A from
-                // the most significant digit down, keeping only candidates that
-                // reproduce the target suffix seen so far.
-                for(int digit = 0; digit < 8; digit++){
-                    long potentialValue = (possibility << 3) + digit;
-                    if(run(program, potentialValue, 0, 0).equals(targetSuffix)){
-                        newPossibilities.add(potentialValue);
+        List<Long> candidates = List.of(0L);
+        for (int from = p.length - 1; from >= 0; from--) {
+            List<Long> next = new ArrayList<>();
+            for (long prefix : candidates) {
+                for (int digit = 0; digit < 8; digit++) {
+                    long value = prefix << 3 | digit;
+                    if (suffix(run(p, value, 0, 0), p, from)) {
+                        next.add(value);
                     }
                 }
             }
-            possibilities = newPossibilities;
+            candidates = next;
         }
-        return possibilities.stream().min(Long::compareTo).orElseThrow() + "";
+        return "" + Collections.min(candidates);
     }
 
-    private List<Integer> run(List<Integer> program, long registerA, long registerB, long registerC){
-        int instructionPointer = 0;
-        List<Integer> result = new ArrayList<>();
-        while(instructionPointer < program.size()){
-            int operator = program.get(instructionPointer);
-            int operand = program.get(instructionPointer + 1); //literal
-            long combo = 0;
-            if(operand < 4){
-                combo = operand;
-            }
-            if(operand == 4){
-                combo = registerA;
-            }
-            if(operand == 5){
-                combo = registerB;
-            }
-            if(operand == 6){
-                combo = registerC;
-            }
-            if(operator == 0){
-                registerA = divideByPowerOfTwo(registerA, combo);
-            }
-            if(operator == 1){
-                registerB ^= operand;
-            }
-            if(operator == 2){
-                registerB = combo % 8;
-            }
-            if(operator == 3){
-                if(registerA != 0){
-                    instructionPointer = operand;
-                    continue;
+    private List<Integer> run(int[] p, long a, long b, long c) {
+        List<Integer> out = new ArrayList<>();
+        for (int i = 0; i < p.length;) {
+            int op = p[i++], x = p[i++];
+            long combo = x < 4 ? x : x == 4 ? a : x == 5 ? b : c;
+            switch (op) {
+                case 0 -> a = shr(a, combo);
+                case 1 -> b ^= x;
+                case 2 -> b = combo & 7;
+                case 3 -> {
+                    if (a != 0) {
+                        i = x;
+                    }
                 }
+                case 4 -> b ^= c;
+                case 5 -> out.add((int) (combo & 7));
+                case 6 -> b = shr(a, combo);
+                case 7 -> c = shr(a, combo);
             }
-            if(operator == 4){
-                registerB ^= registerC;
-            }
-            if(operator == 5){
-                result.add((int) (combo % 8));
-            }
-            if(operator == 6){
-                registerB = divideByPowerOfTwo(registerA, combo);
-            }
-            if(operator == 7){
-                registerC = divideByPowerOfTwo(registerA, combo);
-            }
-            instructionPointer += 2;
         }
-        return result;
+        return out;
     }
 
-    private long divideByPowerOfTwo(long value, long power){
-        if(power >= Long.SIZE){
-            return 0;
+    private long shr(long a, long b) {
+        return b >= 64 ? 0 : a >> b;
+    }
+
+    private boolean suffix(List<Integer> out, int[] p, int from) {
+        if (out.size() != p.length - from) {
+            return false;
         }
-        return value >> power;
+        for (int i = from; i < p.length; i++) {
+            if (out.get(i - from) != p[i]) {
+                return false;
+            }
+        }
+        return true;
     }
 }

--- a/src/solutions/Day17.java
+++ b/src/solutions/Day17.java
@@ -30,7 +30,7 @@ public class Day17 extends DayTemplate {
         return "" + Collections.min(candidates);
     }
 
-    private List<Integer> run(int[] p, long a, long b, long c) {
+    List<Integer> run(int[] p, long a, long b, long c) {
         List<Integer> out = new ArrayList<>();
         for (int i = 0; i < p.length;) {
             int op = p[i++], x = p[i++];
@@ -53,11 +53,11 @@ public class Day17 extends DayTemplate {
         return out;
     }
 
-    private long shr(long a, long b) {
+    long shr(long a, long b) {
         return b >= 64 ? 0 : a >> b;
     }
 
-    private boolean suffix(List<Integer> out, int[] p, int from) {
+    boolean suffix(List<Integer> out, int[] p, int from) {
         if (out.size() != p.length - from) {
             return false;
         }

--- a/src/solutions/Day17.java
+++ b/src/solutions/Day17.java
@@ -6,14 +6,13 @@ import java.util.*;
 
 public class Day17 extends DayTemplate {
     public String solve(boolean part1, Scanner in) {
-        long a = 15401536;
-        in.nextLine();
+        long a = Long.parseLong(in.nextLine().split(" ")[2]);
         long b = Long.parseLong(in.nextLine().split(" ")[2]);
         long c = Long.parseLong(in.nextLine().split(" ")[2]);
         in.nextLine();
         int[] p = Arrays.stream(in.nextLine().split(" ")[1].split(",")).mapToInt(Integer::parseInt).toArray();
         if (part1) {
-            return run(p, a, b, c).toString().replace(" ", "");
+            return run(p, a, b, c).toString().replaceAll("[\\[\\] ]", "");
         }
         List<Long> candidates = List.of(0L);
         for (int from = p.length - 1; from >= 0; from--) {
@@ -21,7 +20,7 @@ public class Day17 extends DayTemplate {
             for (long prefix : candidates) {
                 for (int digit = 0; digit < 8; digit++) {
                     long value = prefix << 3 | digit;
-                    if (suffix(run(p, value, 0, 0), p, from)) {
+                    if (suffix(run(p, value, b, c), p, from)) {
                         next.add(value);
                     }
                 }

--- a/src/solutions/Day18.java
+++ b/src/solutions/Day18.java
@@ -5,7 +5,7 @@ import src.meta.DayTemplate;
 import java.util.*;
 
 public class Day18 extends DayTemplate {
-    private static final int N = 71;
+    static final int N = 71;
 
     public String solve(boolean part1, Scanner in) {
         List<Integer> bytes = new ArrayList<>();
@@ -29,7 +29,7 @@ public class Day18 extends DayTemplate {
         return p % N + "," + p / N;
     }
 
-    private int bfs(List<Integer> bytes, int limit) {
+    int bfs(List<Integer> bytes, int limit) {
         boolean[] bad = new boolean[N * N], seen = new boolean[N * N];
         for (int i = 0; i < limit; i++) {
             bad[bytes.get(i)] = true;

--- a/src/solutions/Day18.java
+++ b/src/solutions/Day18.java
@@ -2,83 +2,55 @@ package src.solutions;
 
 import src.meta.DayTemplate;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Scanner;
+import java.util.*;
 
 public class Day18 extends DayTemplate {
-
-    private static final int GRID_SIZE = 71;
-    private static final int[] DR = {-1, 1, 0, 0};
-    private static final int[] DC = {0, 0, -1, 1};
+    private static final int N = 71;
 
     public String solve(boolean part1, Scanner in) {
         List<Integer> bytes = new ArrayList<>();
         while (in.hasNextLine()) {
-            String line = in.nextLine();
-            int comma = line.indexOf(',');
-            int x = Integer.parseInt(line.substring(0, comma));
-            int y = Integer.parseInt(line.substring(comma + 1));
-            bytes.add(y * GRID_SIZE + x);
+            String[] p = in.nextLine().split(",");
+            bytes.add(Integer.parseInt(p[1]) * N + Integer.parseInt(p[0]));
         }
-
         if (part1) {
-            return bfs(1024, bytes) + "";
+            return "" + bfs(bytes, 1024);
         }
-
-        int high = bytes.size() - 1;
-        int low = 0;
-        while (low < high) {
-            int mid = (low + high) / 2;
-            if (bfs(mid, bytes) == -1) {
-                high = mid;
+        int lo = 0, hi = bytes.size() - 1;
+        while (lo < hi) {
+            int mid = (lo + hi) / 2;
+            if (bfs(bytes, mid) < 0) {
+                hi = mid;
             } else {
-                low = mid + 1;
+                lo = mid + 1;
             }
         }
-        int answer = bytes.get(low - 1);
-        return (answer % GRID_SIZE) + "," + (answer / GRID_SIZE);
+        int p = bytes.get(lo - 1);
+        return p % N + "," + p / N;
     }
 
-    private int bfs(int limit, List<Integer> bytes) {
-        boolean[] blocked = new boolean[GRID_SIZE * GRID_SIZE];
+    private int bfs(List<Integer> bytes, int limit) {
+        boolean[] bad = new boolean[N * N], seen = new boolean[N * N];
         for (int i = 0; i < limit; i++) {
-            blocked[bytes.get(i)] = true;
+            bad[bytes.get(i)] = true;
         }
-
-        boolean[] seen = new boolean[blocked.length];
-        int[] queue = new int[blocked.length];
-        int head = 0;
-        int tail = 0;
-        queue[tail++] = 0;
+        int[] q = new int[N * N], dr = {-1, 1, 0, 0}, dc = {0, 0, -1, 1};
+        int head = 0, tail = 1;
         seen[0] = true;
-        int target = blocked.length - 1;
-        int steps = 0;
-
-        while (head < tail) {
-            int layerEnd = tail;
-            while (head < layerEnd) {
-                int current = queue[head++];
-                if (current == target) {
+        for (int steps = 0; head < tail; steps++) {
+            for (int end = tail; head < end;) {
+                int p = q[head++], r = p / N, c = p % N;
+                if (p == N * N - 1) {
                     return steps;
                 }
-
-                int row = current / GRID_SIZE;
-                int col = current % GRID_SIZE;
-                for (int dir = 0; dir < 4; dir++) {
-                    int nextRow = row + DR[dir];
-                    int nextCol = col + DC[dir];
-                    if (nextRow < 0 || nextCol < 0 || nextRow >= GRID_SIZE || nextCol >= GRID_SIZE) {
-                        continue;
-                    }
-                    int next = nextRow * GRID_SIZE + nextCol;
-                    if (!blocked[next] && !seen[next]) {
-                        seen[next] = true;
-                        queue[tail++] = next;
+                for (int d = 0; d < 4; d++) {
+                    int nr = r + dr[d], nc = c + dc[d], n = nr * N + nc;
+                    if (nr >= 0 && nc >= 0 && nr < N && nc < N && !bad[n] && !seen[n]) {
+                        seen[n] = true;
+                        q[tail++] = n;
                     }
                 }
             }
-            steps++;
         }
         return -1;
     }

--- a/src/solutions/Day19.java
+++ b/src/solutions/Day19.java
@@ -1,80 +1,39 @@
 package src.solutions;
 
 import src.meta.DayTemplate;
+
 import java.util.*;
 
 public class Day19 extends DayTemplate {
-
-    private TowelNode root;
+    private String[] towels;
+    private Map<String, Long> memo;
 
     public String solve(boolean part1, Scanner in) {
-        long answer = 0;
-        root = new TowelNode();
-        for (String towel : in.nextLine().split(", ")) {
-            addTowel(towel);
-        }
+        towels = in.nextLine().split(", ");
         in.nextLine();
-        while(in.hasNext()){
-            String line = in.nextLine();
-            if(part1){
-                answer += canMake(line) ? 1 : 0;
-            }
-            else{
-                answer += number(line);
-            }
+        long answer = 0;
+        while (in.hasNextLine()) {
+            memo = new HashMap<>();
+            long ways = ways(in.nextLine());
+            answer += part1 ? ways > 0 ? 1 : 0 : ways;
         }
-        return answer + "";
+        return "" + answer;
     }
 
-    private void addTowel(String towel) {
-        TowelNode current = root;
-        for (int i = 0; i < towel.length(); i++) {
-            current = current.next.computeIfAbsent(towel.charAt(i), key -> new TowelNode());
+    private long ways(String design) {
+        if (design.isEmpty()) {
+            return 1;
         }
-        current.end = true;
-    }
-
-    private long number(String towel){
-        long[] possibilities = new long[towel.length() + 1];
-        possibilities[towel.length()] = 1L;
-        for (int start = towel.length() - 1; start >= 0; start--) {
-            TowelNode current = root;
-            long result = 0L;
-            for (int end = start; end < towel.length(); end++) {
-                current = current.next.get(towel.charAt(end));
-                if (current == null) {
-                    break;
-                }
-                if (current.end) {
-                    result += possibilities[end + 1];
-                }
-            }
-            possibilities[start] = result;
+        if (memo.containsKey(design)) {
+            return memo.get(design);
         }
-        return possibilities[0];
-    }
-
-    private boolean canMake(String towel) {
-        boolean[] possible = new boolean[towel.length() + 1];
-        possible[towel.length()] = true;
-        for (int start = towel.length() - 1; start >= 0; start--) {
-            TowelNode current = root;
-            for (int end = start; end < towel.length(); end++) {
-                current = current.next.get(towel.charAt(end));
-                if (current == null) {
-                    break;
-                }
-                if (current.end && possible[end + 1]) {
-                    possible[start] = true;
-                    break;
-                }
+        long total = 0;
+        for (String towel : towels) {
+            if (design.startsWith(towel)) {
+                total += ways(design.substring(towel.length()));
             }
         }
-        return possible[0];
-    }
-
-    private static class TowelNode {
-        private boolean end;
-        private Map<Character, TowelNode> next = new HashMap<>();
+        memo.put(design, total);
+        return total;
     }
 }

--- a/src/solutions/Day19.java
+++ b/src/solutions/Day19.java
@@ -5,8 +5,8 @@ import src.meta.DayTemplate;
 import java.util.*;
 
 public class Day19 extends DayTemplate {
-    private String[] towels;
-    private Map<String, Long> memo;
+    String[] towels;
+    Map<String, Long> memo;
 
     public String solve(boolean part1, Scanner in) {
         towels = in.nextLine().split(", ");
@@ -20,7 +20,7 @@ public class Day19 extends DayTemplate {
         return "" + answer;
     }
 
-    private long ways(String design) {
+    long ways(String design) {
         if (design.isEmpty()) {
             return 1;
         }

--- a/src/solutions/Day20.java
+++ b/src/solutions/Day20.java
@@ -1,124 +1,83 @@
 package src.solutions;
 
 import src.meta.DayTemplate;
+
 import java.util.*;
 
 public class Day20 extends DayTemplate {
-
-    private boolean[] walls;
-    private int rows;
-    private int cols;
+    private int rows, cols;
+    private boolean[] wall;
 
     public String solve(boolean part1, Scanner in) {
-        long answer = 0;
         List<String> lines = new ArrayList<>();
-        while (in.hasNext()) {
-            String line = in.nextLine();
-            lines.add(line);
+        while (in.hasNextLine()) {
+            lines.add(in.nextLine());
         }
         rows = lines.size();
         cols = lines.get(0).length();
-        walls = new boolean[rows * cols];
-        int startX = -1;
-        int startY = -1;
-        int endX = -1;
-        int endY = -1;
-        for(int i = 0 ; i < rows; i++){
-            for(int j = 0; j < cols; j++){
-                char c = lines.get(i).charAt(j);
-                if(c == 'S'){
-                    startX = i;
-                    startY = j;
-                }
-                if(c == 'E'){
-                    endX = i;
-                    endY = j;
-                }
-                if(c == '#'){
-                    walls[toIndex(i, j)] = true;
+        wall = new boolean[rows * cols];
+        int start = 0, end = 0;
+        for (int r = 0; r < rows; r++) {
+            for (int c = 0; c < cols; c++) {
+                char ch = lines.get(r).charAt(c);
+                if (ch == '#') {
+                    wall[id(r, c)] = true;
+                } else if (ch == 'S') {
+                    start = id(r, c);
+                } else if (ch == 'E') {
+                    end = id(r, c);
                 }
             }
         }
-
-        int start = toIndex(startX, startY);
-        int end = toIndex(endX, endY);
-        int[] bfsFromEnd = bfs(end);
-        int[] bfsFromStart = bfs(start);
-        int currentDistance = bfsFromEnd[start];
-        int maxCheat = part1 ? 2 : 20;
-        int targetDistance = currentDistance - 100;
-        for(int x = 0; x < rows; x++){
-            int rowStart = x * cols;
-            for(int y = 0; y < cols; y++){
-                int startDistance = bfsFromStart[rowStart + y];
-                if(startDistance < 0){
+        int[] fromStart = bfs(start), toEnd = bfs(end);
+        int max = part1 ? 2 : 20, target = toEnd[start] - 100;
+        long total = 0;
+        for (int r = 0; r < rows; r++) {
+            for (int c = 0; c < cols; c++) {
+                int a = fromStart[id(r, c)];
+                if (a < 0) {
                     continue;
                 }
-                int minDx = Math.max(-maxCheat, -x);
-                int maxDx = Math.min(maxCheat, rows - 1 - x);
-                for(int dx = minDx; dx <= maxDx; dx++){
-                    int nx = x + dx;
-                    int absDx = Math.abs(dx);
-                    int yRange = maxCheat - absDx;
-                    int targetRowStart = nx * cols;
-                    int minY = Math.max(0, y - yRange);
-                    int maxY = Math.min(cols - 1, y + yRange);
-                    for(int ny = minY; ny <= maxY; ny++){
-                        int endDistance = bfsFromEnd[targetRowStart + ny];
-                        if(endDistance >= 0 && startDistance + endDistance + absDx + Math.abs(ny - y) <= targetDistance){
-                            answer++;
+                for (int dr = -max; dr <= max; dr++) {
+                    int nr = r + dr, left = max - Math.abs(dr);
+                    if (nr < 0 || nr >= rows) {
+                        continue;
+                    }
+                    for (int nc = Math.max(0, c - left); nc <= Math.min(cols - 1, c + left); nc++) {
+                        int b = toEnd[id(nr, nc)];
+                        if (b >= 0 && a + b + Math.abs(dr) + Math.abs(nc - c) <= target) {
+                            total++;
                         }
                     }
                 }
             }
         }
-        return answer + "";
+        return "" + total;
     }
 
-    private int[] bfs(int start){
-        int[] distances = new int[rows * cols];
-        Arrays.fill(distances, -1);
-
-        int[] queue = new int[rows * cols];
-        int head = 0;
-        int tail = 0;
-        distances[start] = 0;
-        queue[tail++] = start;
-
-        while(head < tail){
-            int current = queue[head++];
-            int x = current / cols;
-            int y = current - x * cols;
-            int nextDistance = distances[current] + 1;
-
-            int next = current - cols;
-            if(x > 0 && !walls[next] && distances[next] < 0){
-                distances[next] = nextDistance;
-                queue[tail++] = next;
-            }
-
-            next = current + cols;
-            if(x + 1 < rows && !walls[next] && distances[next] < 0){
-                distances[next] = nextDistance;
-                queue[tail++] = next;
-            }
-
-            next = current - 1;
-            if(y > 0 && !walls[next] && distances[next] < 0){
-                distances[next] = nextDistance;
-                queue[tail++] = next;
-            }
-
-            next = current + 1;
-            if(y + 1 < cols && !walls[next] && distances[next] < 0){
-                distances[next] = nextDistance;
-                queue[tail++] = next;
+    private int[] bfs(int start) {
+        int[] dist = new int[rows * cols], q = new int[dist.length], step = {-cols, cols, -1, 1};
+        Arrays.fill(dist, -1);
+        dist[start] = 0;
+        int head = 0, tail = 1;
+        q[0] = start;
+        while (head < tail) {
+            int p = q[head++], r = p / cols, c = p % cols;
+            for (int d : step) {
+                int n = p + d;
+                if ((d == -1 && c == 0) || (d == 1 && c == cols - 1) || n < 0 || n >= dist.length) {
+                    continue;
+                }
+                if (!wall[n] && dist[n] < 0) {
+                    dist[n] = dist[p] + 1;
+                    q[tail++] = n;
+                }
             }
         }
-        return distances;
+        return dist;
     }
 
-    private int toIndex(int x, int y){
-        return x * cols + y;
+    private int id(int r, int c) {
+        return r * cols + c;
     }
 }

--- a/src/solutions/Day20.java
+++ b/src/solutions/Day20.java
@@ -5,8 +5,8 @@ import src.meta.DayTemplate;
 import java.util.*;
 
 public class Day20 extends DayTemplate {
-    private int rows, cols;
-    private boolean[] wall;
+    int rows, cols;
+    boolean[] wall;
 
     public String solve(boolean part1, Scanner in) {
         List<String> lines = new ArrayList<>();
@@ -55,7 +55,7 @@ public class Day20 extends DayTemplate {
         return "" + total;
     }
 
-    private int[] bfs(int start) {
+    int[] bfs(int start) {
         int[] dist = new int[rows * cols], q = new int[dist.length], step = {-cols, cols, -1, 1};
         Arrays.fill(dist, -1);
         dist[start] = 0;
@@ -77,7 +77,7 @@ public class Day20 extends DayTemplate {
         return dist;
     }
 
-    private int id(int r, int c) {
+    int id(int r, int c) {
         return r * cols + c;
     }
 }

--- a/src/solutions/Day21.java
+++ b/src/solutions/Day21.java
@@ -1,474 +1,91 @@
 package src.solutions;
 
 import src.meta.DayTemplate;
-import src.objects.Coordinate;
 
 import java.util.*;
 
 public class Day21 extends DayTemplate {
+    private static final String[] NUM = {"789", "456", "123", " 0A"}, DIR = {" ^A", "<v>"};
+    private final Map<String, Long> memo = new HashMap<>();
 
-    List<Coordinate> numPad = new ArrayList<>();
-    List<Coordinate> dirPad = new ArrayList<>();
-    Map<Character, Integer> dirMap;
     public String solve(boolean part1, Scanner in) {
         long answer = 0;
-        String[] inputs = new String[5];
-        inputs[0] = in.nextLine();
-        inputs[1] = in.nextLine();
-        inputs[2] = in.nextLine();
-        inputs[3] = in.nextLine();
-        inputs[4] = in.nextLine();
-        numPad.add(new Coordinate(3,1));
-        numPad.add(new Coordinate(2,0));
-        numPad.add(new Coordinate(2,1));
-        numPad.add(new Coordinate(2,2));
-        numPad.add(new Coordinate(1,0));
-        numPad.add(new Coordinate(1,1));
-        numPad.add(new Coordinate(1,2));
-        numPad.add(new Coordinate(0,0));
-        numPad.add(new Coordinate(0,1));
-        numPad.add(new Coordinate(0,2));
-        numPad.add(new Coordinate(3,2));
-        dirMap = Map.of('<', 0, 'v', 1, '>', 2, '^',3,'A',4);
-        dirPad.add(new Coordinate(1,0));
-        dirPad.add(new Coordinate(1,1));
-        dirPad.add(new Coordinate(1,2));
-        dirPad.add(new Coordinate(0,1));
-        dirPad.add(new Coordinate(0,2));
-
-        for(String input: inputs){
-            long a = shortest(input, part1);
-            long b = Integer.parseInt(input.substring(0, input.length() - 1));
-            answer +=  a * b;
+        while (in.hasNextLine()) {
+            String code = in.nextLine();
+            long n = Long.parseLong(code.substring(0, code.length() - 1)), cost = 0;
+            char from = 'A';
+            for (char to : code.toCharArray()) {
+                cost += cost(from, to, part1 ? 2 : 25, NUM);
+                from = to;
+            }
+            answer += n * cost;
         }
-        return answer + "";
+        return "" + answer;
     }
 
-    private long shortest(String input, boolean part1){
-        Set<String> currentLayer = shortestNumeric(input);
-        for(int i = 0; i < 1; i++){
-            Set<String> newLayer = new HashSet<>();
-            for(String s: currentLayer){
-                newLayer.addAll(shortestDirectional(s));
-            }
-            currentLayer = newLayer;
+    private long cost(char from, char to, int depth, String[] pad) {
+        String key = (pad == NUM ? "N" : "D") + from + to + depth;
+        if (memo.containsKey(key)) {
+            return memo.get(key);
         }
-        long result = -1;
-        for(String s: currentLayer){
-            Map<String, Long> parts = iterate(s, (part1?1:24));
-            long interimResult = 0;
-            for(String key: parts.keySet()){
-                interimResult += parts.get(key) * (key.length() + 1);
-            }
-            if(result == -1 || result > interimResult){
-                result = interimResult;
-            }
+        long best = Long.MAX_VALUE;
+        for (String path : paths(from, to, pad)) {
+            best = Math.min(best, sequence(path + "A", depth));
         }
-        return result;
-
+        memo.put(key, best);
+        return best;
     }
 
-    private Map<String, Long> iterate(String s, int iterations){
-        Map <String, Long> map = convert(s);
-        while(iterations-- > 0){
-            map = iterateOne(map);
+    private long sequence(String path, int depth) {
+        if (depth == 0) {
+            return path.length();
         }
-        return map;
+        long total = 0;
+        char from = 'A';
+        for (char to : path.toCharArray()) {
+            total += cost(from, to, depth - 1, DIR);
+            from = to;
+        }
+        return total;
     }
 
-    private Map<String, Long> convert(String s){
-        Map<String, Long> result = new HashMap<>();
-        String[] parts = s.split("A");
-        for(String part: parts){
-            result.put(part, result.getOrDefault(part, 0L) + 1);
+    private List<String> paths(char from, char to, String[] pad) {
+        int ar = 0, ac = 0, br = 0, bc = 0;
+        for (int r = 0; r < pad.length; r++) {
+            for (int c = 0; c < pad[r].length(); c++) {
+                if (pad[r].charAt(c) == from) {
+                    ar = r;
+                    ac = c;
+                }
+                if (pad[r].charAt(c) == to) {
+                    br = r;
+                    bc = c;
+                }
+            }
         }
-        return result;
+        List<String> out = new ArrayList<>(), q = new ArrayList<>();
+        q.add(ar + "," + ac + ",");
+        for (int i = 0; i < q.size(); i++) {
+            String[] state = q.get(i).split(",", 3);
+            int r = Integer.parseInt(state[0]), c = Integer.parseInt(state[1]);
+            String path = state[2];
+            if (r == br && c == bc) {
+                out.add(path);
+                continue;
+            }
+            add(q, pad, r, c, r - 1, c, br, bc, path, '^');
+            add(q, pad, r, c, r + 1, c, br, bc, path, 'v');
+            add(q, pad, r, c, r, c - 1, br, bc, path, '<');
+            add(q, pad, r, c, r, c + 1, br, bc, path, '>');
+        }
+        return out;
     }
 
-    private Map<String, Long> iterateOne(Map<String, Long> map){
-        Map<String, Long> result = new HashMap<>();
-        for(String s: map.keySet()) {
-            long val = map.get(s);
-            long first;
-            long second;
-            long third;
-            long fourth;
-            switch (s) {
-                case "":
-                    first = result.getOrDefault("", 0L);
-                    result.put("", first + val);
-                    break;
-                case ">":
-                    first = result.getOrDefault("v", 0L);
-                    result.put("v", first + val);
-                    second = result.getOrDefault("^", 0L);
-                    result.put("^", second + val);
-                    break;
-                case ">>":
-                    first = result.getOrDefault("v", 0L);
-                    result.put("v", first + val);
-                    second = result.getOrDefault("", 0L);
-                    result.put("", second + val);
-                    third = result.getOrDefault("^", 0L);
-                    result.put("^", third + val);
-                    break;
-                case "<":
-                    first = result.getOrDefault("v<<", 0L);
-                    result.put("v<<", first + val);
-                    second = result.getOrDefault(">>^", 0L);
-                    result.put(">>^", second + val);
-                    break;
-                case "<<":
-                    first = result.getOrDefault("v<<", 0L);
-                    result.put("v<<", first + val);
-                    second = result.getOrDefault("", 0L);
-                    result.put("", second + val);
-                    third = result.getOrDefault(">>^", 0L);
-                    result.put(">>^", third + val);
-                    break;
-                case "^":
-                    first = result.getOrDefault("<", 0L);
-                    result.put("<", first + val);
-                    second = result.getOrDefault(">", 0L);
-                    result.put(">", second + val);
-                    break;
-                case "v":
-                    first = result.getOrDefault("<v", 0L);
-                    result.put("<v", first + val);
-                    second = result.getOrDefault("^>", 0L);
-                    result.put("^>", second + val);
-                    break;
-                case "v<<":
-                    //v<A<AA>>^A
-                    first = result.getOrDefault("<v", 0L);
-                    result.put("<v", first + val);
-                    second = result.getOrDefault("<", 0L);
-                    result.put("<", second + val);
-                    third = result.getOrDefault("", 0L);
-                    result.put("", third + val);
-                    fourth = result.getOrDefault(">>^", 0L);
-                    result.put(">>^", fourth + val);
-                    break;
-                case ">>^":
-                    //vAA<^A>A
-                    first = result.getOrDefault("v", 0L);
-                    result.put("v", first + val);
-                    second = result.getOrDefault("", 0L);
-                    result.put("", second + val);
-                    third = result.getOrDefault("<^", 0L);
-                    result.put("<^", third + val);
-                    fourth = result.getOrDefault(">", 0L);
-                    result.put(">", fourth + val);
-                    break;
-                case "v>":
-                    //v<A>A^A
-                    first = result.getOrDefault("<v", 0L);
-                    result.put("<v", first + val);
-                    second = result.getOrDefault(">", 0L);
-                    result.put(">", second + val);
-                    third = result.getOrDefault("^", 0L);
-                    result.put("^", third + val);
-                    break;
-                case "^>":
-                    //<A>vA^A
-                    first = result.getOrDefault("<", 0L);
-                    result.put("<", first + val); //2 things 6 char
-                    second = result.getOrDefault("v>", 0L);
-                    result.put("v>", second + val); //3 things, 4 char
-                    third = result.getOrDefault("^", 0L);
-                    result.put("^", third + val); //2 things, 2 char
-                    break;
-                case ">^":
-                    //vA<^A>A
-                    first = result.getOrDefault("v", 0L);
-                    result.put("v", first + val); //2 things 4 char
-                    second = result.getOrDefault("<^", 0L);
-                    result.put("<^", second + val); //3 things 6 char
-                    third = result.getOrDefault(">", 0L);
-                    result.put(">", third + val); //2 things 2 char
-                    break;
-                case "v<":
-                    first = result.getOrDefault("<v", 0L);
-                    result.put("<v", first + val);
-                    second = result.getOrDefault("<", 0L);
-                    result.put("<", second + val);
-                    third = result.getOrDefault(">>^", 0L);
-                    result.put(">>^", third + val);
-                    break;
-                case "<v":
-                    //v<<A>A>^A
-                    first = result.getOrDefault("v<<", 0L);
-                    result.put("v<<", first + val);
-                    second = result.getOrDefault(">", 0L);
-                    result.put(">", second + val);
-                    third = result.getOrDefault("^>", 0L);
-                    result.put("^>", third + val);
-                    break;
-                case "<^":
-                    //v<<A>^A>A
-                    first = result.getOrDefault("v<<", 0L);
-                    result.put("v<<", first + val);
-                    second = result.getOrDefault(">^", 0L);
-                    result.put(">^", second + val);
-                    third = result.getOrDefault(">", 0L);
-                    result.put(">", third + val);
-                    break;
-                default:
-                    System.out.println(s);
-            }
+    private void add(List<String> q, String[] pad, int oldR, int oldC, int r, int c, int br, int bc, String path, char move) {
+        if (r >= 0 && r < pad.length && c >= 0 && c < pad[r].length()
+                && pad[r].charAt(c) != ' '
+                && Math.abs(r - br) + Math.abs(c - bc) < Math.abs(oldR - br) + Math.abs(oldC - bc)) {
+            q.add(r + "," + c + "," + path + move);
         }
-
-        return result;
-    }
-
-    private Set<String> shortestNumeric(String input){
-        int size = -1;
-        Set<String> paths = new HashSet<>();
-        paths.add("");
-        Set<String> newPaths = new HashSet<>();
-        for(String path: paths){
-            for(String addition: shortestNumericHelper(numPad.get(10), numPad.get(input.charAt(0) - '0'))){
-                newPaths.add(path + addition + "A");
-            }
-        }
-        paths= newPaths;
-
-        for(int i = 0; i < input.length() - 1; i++){
-            int beginning = (input.charAt(i) == 'A')?10:(input.charAt(i) - '0');
-            int end = (input.charAt(i + 1) == 'A')?10:(input.charAt(i + 1) - '0');
-            newPaths = new HashSet<>();
-            for(String path: paths){
-                for(String addition: shortestNumericHelper(numPad.get(beginning), numPad.get(end))){
-                    newPaths.add(path + addition + "A");
-                }
-            }
-            paths= newPaths;
-        }
-        for(String path: paths){
-            if(size == -1 || path.length() < size){
-                size = path.length();
-            }
-        }
-
-        Set<String> result = new HashSet<>();
-        for(String path: paths){
-            if(size == path.length()){
-                result.add(path);
-            }
-        }
-
-        return result;
-    }
-
-    private Set<String> shortestNumericHelper(Coordinate a, Coordinate b){
-        Set<String> results = new HashSet<>();
-        if(a.x == 3 && a.y == 1 && b.x == 2 && b.y == 0){
-            results.add("^<");
-            return results;
-        }
-        if(a.x == 2 && a.y == 0 && b.x == 3 && b.y == 1){
-            results.add(">v");
-            return results;
-        }
-        if(a.x == b.x){
-            if(a.y == b.y){
-                results.add("");
-                return results;
-            }
-            if(a.y > b.y){
-                String possibility = "<";
-                for(String remaining: shortestNumericHelper(new Coordinate(a.x, a.y - 1), b)){
-                    results.add(possibility + remaining);
-                }
-                return results;
-            }
-            if(a.y < b.y){
-                String possibility = ">";
-                for(String remaining: shortestNumericHelper(new Coordinate(a.x, a.y + 1), b)){
-                    results.add(possibility + remaining);
-                }
-                return results;
-            }
-        }
-        if(a.y == b.y){
-            if(a.x > b.x){
-                String possibility = "^";
-                for(String remaining: shortestNumericHelper(new Coordinate(a.x - 1, a.y), b)){
-                    results.add(possibility + remaining);
-                }
-                return results;
-            }
-            if(a.x < b.x){
-                String possibility = "v";
-                for(String remaining: shortestNumericHelper(new Coordinate(a.x + 1, a.y), b)){
-                    results.add(possibility + remaining);
-                }
-                return results;
-            }
-        }
-        if(a.x > b.x && a.y > b.y){
-            String possibility1 = "^";
-            for(String remaining: shortestNumericHelper(new Coordinate(a.x - 1, a.y), b)){
-                results.add(possibility1 + remaining);
-            }
-            if(!(a.x == 3 ) || !(a.y == 1)){
-                String possibility2 = "<";
-                for(String remaining: shortestNumericHelper(new Coordinate(a.x, a.y - 1), b)){
-                    results.add(possibility2 + remaining);
-                }
-            }
-        }
-        if(a.x < b.x && a.y > b.y){
-            String possibility1 = "v";
-            for(String remaining: shortestNumericHelper(new Coordinate(a.x + 1, a.y), b)){
-                results.add(possibility1 + remaining);
-            }
-            String possibility2 = "<";
-            for(String remaining: shortestNumericHelper(new Coordinate(a.x, a.y - 1), b)){
-                results.add(possibility2 + remaining);
-            }
-        }
-        if(a.x > b.x && a.y < b.y){
-            String possibility1 = "^";
-            for(String remaining: shortestNumericHelper(new Coordinate(a.x - 1, a.y), b)){
-                results.add(possibility1 + remaining);
-            }
-            String possibility2 = ">";
-            for(String remaining: shortestNumericHelper(new Coordinate(a.x, a.y + 1), b)){
-                results.add(possibility2 + remaining);
-            }
-        }
-        if(a.x < b.x && a.y < b.y){
-            if(!(a.x == 2 ) || !(a.y == 0)) {
-                String possibility1 = "v";
-                for (String remaining : shortestNumericHelper(new Coordinate(a.x + 1, a.y), b)) {
-                    results.add(possibility1 + remaining);
-                }
-            }
-            String possibility2 = ">";
-            for(String remaining: shortestNumericHelper(new Coordinate(a.x, a.y + 1), b)){
-                results.add(possibility2 + remaining);
-            }
-        }
-
-
-        return results;
-    }
-
-    private Set<String> shortestDirectional(String input){
-        Set<String> paths = new HashSet<>();
-        paths.add("");
-        Set<String> newPaths = new HashSet<>();
-        for(String path: paths){
-            for(String addition: shortestDirectionalHelper(dirPad.get(dirMap.get('A')), dirPad.get(dirMap.get(input.charAt(0))))){
-                newPaths.add(path + addition + "A");
-            }
-        }
-        paths = newPaths;
-
-        for(int i = 0; i < input.length() - 1; i++){
-            int beginning = dirMap.get(input.charAt(i));
-            int end = dirMap.get(input.charAt(i + 1));
-            newPaths = new HashSet<>();
-            for(String path: paths){
-                for(String addition: shortestDirectionalHelper(dirPad.get(beginning), dirPad.get(end))){
-                    newPaths.add(path + addition + "A");
-                }
-            }
-            paths= newPaths;
-        }
-        int size = -1;
-        for(String path: paths){
-            if(size == -1 || path.length() < size){
-                size = path.length();
-            }
-        }
-
-        Set<String> result = new HashSet<>();
-        for(String path: paths){
-            if(size == path.length()){
-                result.add(path);
-            }
-        }
-
-        return result;
-    }
-
-    private Set<String> shortestDirectionalHelper(Coordinate a, Coordinate b){
-        Set<String> results = new HashSet<>();
-        if(a.x == 1 && a.y == 0 && b.x == 0 && b.y == 1){
-            results.add(">^");
-            return results;
-        }
-        if(a.x == 0 && a.y == 1 && b.x == 1 && b.y == 0){
-            results.add("v<");
-            return results;
-        }
-        if(a.x == 0 && a.y == 2 && b.x == 1 && b.y == 0){
-            results.add("v<<");
-            return results;
-        }
-        if(a.x == 0 && a.y == 2 && b.x == 1 && b.y == 1){
-            results.add("<v");
-            return results;
-        }
-        if(a.x == 1 && a.y == 2 && b.x == 0 && b.y == 1){
-            results.add("<^");
-            return results;
-        }
-        if(a.x == 1 && a.y == 1 && b.x == 0 && b.y == 2){
-            results.add("^>");
-            return results;
-        }
-        if(a.x == 1 && a.y == 0 && b.x == 0 && b.y == 2){
-            results.add(">>^");
-            return results;
-        }
-        if(a.x == 0 && a.y == 1 && b.x == 1 && b.y == 2){
-            results.add("v>");
-            return results;
-        }
-        if(a.x == b.x){
-            if(a.y == b.y){
-                results.add("");
-                return results;
-            }
-            if(a.y > b.y){
-                String possibility = "";
-                for(int i = 0; i < a.y - b.y; i++){
-                    possibility += "<";
-                }
-                results.add(possibility);
-                return results;
-            }
-            if(a.y < b.y){
-                String possibility = "";
-                for(int i = 0; i < b.y - a.y; i++){
-                    possibility += ">";
-                }
-                results.add(possibility);
-                return results;
-            }
-        }
-        if(a.y == b.y){
-            if(a.x > b.x){
-                String possibility = "";
-                for(int i = 0; i < a.x - b.x; i++){
-                    possibility += "^";
-                }
-                results.add(possibility);
-                return results;
-            }
-            if(a.x < b.x){
-                String possibility = "";
-                for(int i = 0; i < b.x - a.x; i++){
-                    possibility += "v";
-                }
-                results.add(possibility);
-                return results;
-            }
-        }
-
-        return results;
     }
 }

--- a/src/solutions/Day21.java
+++ b/src/solutions/Day21.java
@@ -5,8 +5,8 @@ import src.meta.DayTemplate;
 import java.util.*;
 
 public class Day21 extends DayTemplate {
-    private static final String[] NUM = {"789", "456", "123", " 0A"}, DIR = {" ^A", "<v>"};
-    private final Map<String, Long> memo = new HashMap<>();
+    static final String[] NUM = {"789", "456", "123", " 0A"}, DIR = {" ^A", "<v>"};
+    final Map<String, Long> memo = new HashMap<>();
 
     public String solve(boolean part1, Scanner in) {
         long answer = 0;
@@ -23,7 +23,7 @@ public class Day21 extends DayTemplate {
         return "" + answer;
     }
 
-    private long cost(char from, char to, int depth, String[] pad) {
+    long cost(char from, char to, int depth, String[] pad) {
         String key = (pad == NUM ? "N" : "D") + from + to + depth;
         if (memo.containsKey(key)) {
             return memo.get(key);
@@ -36,7 +36,7 @@ public class Day21 extends DayTemplate {
         return best;
     }
 
-    private long sequence(String path, int depth) {
+    long sequence(String path, int depth) {
         if (depth == 0) {
             return path.length();
         }
@@ -49,7 +49,7 @@ public class Day21 extends DayTemplate {
         return total;
     }
 
-    private List<String> paths(char from, char to, String[] pad) {
+    List<String> paths(char from, char to, String[] pad) {
         int ar = 0, ac = 0, br = 0, bc = 0;
         for (int r = 0; r < pad.length; r++) {
             for (int c = 0; c < pad[r].length(); c++) {
@@ -81,7 +81,7 @@ public class Day21 extends DayTemplate {
         return out;
     }
 
-    private void add(List<String> q, String[] pad, int oldR, int oldC, int r, int c, int br, int bc, String path, char move) {
+    void add(List<String> q, String[] pad, int oldR, int oldC, int r, int c, int br, int bc, String path, char move) {
         if (r >= 0 && r < pad.length && c >= 0 && c < pad[r].length()
                 && pad[r].charAt(c) != ' '
                 && Math.abs(r - br) + Math.abs(c - bc) < Math.abs(oldR - br) + Math.abs(oldC - bc)) {

--- a/src/solutions/Day22.java
+++ b/src/solutions/Day22.java
@@ -1,13 +1,11 @@
-// Inspired by https://github.com/maneatingape/advent-of-code-rust/blob/main/src/year2024/day22.rs
-// for encoding four price changes as base-19 digits instead of sparse bit-packed indices.
 package src.solutions;
 
 import src.meta.DayTemplate;
 import java.util.*;
 
 public class Day22 extends DayTemplate {
-    private static final int MASK = (1 << 24) - 1;
-    private static final int SEQUENCE_COUNT = 19 * 19 * 19 * 19;
+    static final int MASK = (1 << 24) - 1;
+    static final int SEQUENCE_COUNT = 19 * 19 * 19 * 19;
 
     public String solve(boolean part1, Scanner in) {
         long answer = 0;
@@ -61,7 +59,7 @@ public class Day22 extends DayTemplate {
         return answer + "";
     }
 
-    private int oneIteration(int secret){
+    int oneIteration(int secret){
         secret = (secret ^ (secret << 6)) & MASK;
         secret = (secret ^ (secret >> 5)) & MASK;
         return (secret ^ (secret << 11)) & MASK;

--- a/src/solutions/Day23.java
+++ b/src/solutions/Day23.java
@@ -5,12 +5,12 @@ import src.meta.DayTemplate;
 import java.util.*;
 
 public class Day23 extends DayTemplate {
-    private final Map<String, Integer> ids = new HashMap<>();
-    private final List<String> names = new ArrayList<>();
-    private final List<BitSet> graph = new ArrayList<>();
-    private boolean[] startsT;
-    private BitSet best = new BitSet();
-    private int bs;
+    final Map<String, Integer> ids = new HashMap<>();
+    final List<String> names = new ArrayList<>();
+    final List<BitSet> graph = new ArrayList<>();
+    boolean[] startsT;
+    BitSet best = new BitSet();
+    int bs;
 
     public String solve(boolean part1, Scanner in) {
         while (in.hasNextLine()) {
@@ -37,7 +37,7 @@ public class Day23 extends DayTemplate {
         return String.join(",", out);
     }
 
-    private int id(String name) {
+    int id(String name) {
         return ids.computeIfAbsent(name, k -> {
             names.add(k);
             graph.add(new BitSet());
@@ -45,7 +45,7 @@ public class Day23 extends DayTemplate {
         });
     }
 
-    private long triangles() {
+    long triangles() {
         long total = 0;
         for (int a = 0; a < names.size(); a++) {
             for (int b = graph.get(a).nextSetBit(a + 1); b >= 0; b = graph.get(a).nextSetBit(b + 1)) {
@@ -61,7 +61,7 @@ public class Day23 extends DayTemplate {
         return total;
     }
 
-    private void clique(BitSet keep, BitSet can, BitSet skip) {
+    void clique(BitSet keep, BitSet can, BitSet skip) {
         int size = keep.cardinality();
         if (size + can.cardinality() <= bs) {
             return;
@@ -87,7 +87,7 @@ public class Day23 extends DayTemplate {
         }
     }
 
-    private int pivot(BitSet can, BitSet skip) {
+    int pivot(BitSet can, BitSet skip) {
         BitSet all = (BitSet) can.clone();
         all.or(skip);
         int pick = -1, most = -1;

--- a/src/solutions/Day23.java
+++ b/src/solutions/Day23.java
@@ -5,67 +5,54 @@ import src.meta.DayTemplate;
 import java.util.*;
 
 public class Day23 extends DayTemplate {
-
-    private final Map<String, Integer> nameToIndex = new HashMap<>();
+    private final Map<String, Integer> ids = new HashMap<>();
     private final List<String> names = new ArrayList<>();
-    private final List<BitSet> connections = new ArrayList<>();
-    private boolean[] startsWithT;
-    private BitSet bestClique;
-    private int bestCliqueSize;
+    private final List<BitSet> graph = new ArrayList<>();
+    private boolean[] startsT;
+    private BitSet best = new BitSet();
+    private int bs;
 
     public String solve(boolean part1, Scanner in) {
-        readConnections(in);
-        if (part1) {
-            return countTrianglesWithT() + "";
-        }
-        findLargestClique();
-        return cliqueToString(bestClique);
-    }
-
-    private void readConnections(Scanner in) {
-        nameToIndex.clear();
-        names.clear();
-        connections.clear();
-
         while (in.hasNextLine()) {
-            String line = in.nextLine();
-            if (line.isEmpty()) {
-                continue;
-            }
-            int split = line.indexOf('-');
-            int first = indexFor(line.substring(0, split));
-            int second = indexFor(line.substring(split + 1));
-            connections.get(first).set(second);
-            connections.get(second).set(first);
+            String[] p = in.nextLine().split("-");
+            int a = id(p[0]), b = id(p[1]);
+            graph.get(a).set(b);
+            graph.get(b).set(a);
         }
-
-        startsWithT = new boolean[names.size()];
+        startsT = new boolean[names.size()];
         for (int i = 0; i < names.size(); i++) {
-            startsWithT[i] = names.get(i).startsWith("t");
+            startsT[i] = names.get(i).startsWith("t");
         }
+        if (part1) {
+            return "" + triangles();
+        }
+        BitSet all = new BitSet(names.size());
+        all.set(0, names.size());
+        clique(new BitSet(), all, new BitSet());
+        List<String> out = new ArrayList<>();
+        for (int i = best.nextSetBit(0); i >= 0; i = best.nextSetBit(i + 1)) {
+            out.add(names.get(i));
+        }
+        Collections.sort(out);
+        return String.join(",", out);
     }
 
-    private int indexFor(String name) {
-        Integer existing = nameToIndex.get(name);
-        if (existing != null) {
-            return existing;
-        }
-        int index = names.size();
-        nameToIndex.put(name, index);
-        names.add(name);
-        connections.add(new BitSet());
-        return index;
+    private int id(String name) {
+        return ids.computeIfAbsent(name, k -> {
+            names.add(k);
+            graph.add(new BitSet());
+            return names.size() - 1;
+        });
     }
 
-    private long countTrianglesWithT() {
+    private long triangles() {
         long total = 0;
-        for (int first = 0; first < names.size(); first++) {
-            BitSet firstConnections = connections.get(first);
-            for (int second = firstConnections.nextSetBit(first + 1); second >= 0; second = firstConnections.nextSetBit(second + 1)) {
-                BitSet common = (BitSet) firstConnections.clone();
-                common.and(connections.get(second));
-                for (int third = common.nextSetBit(second + 1); third >= 0; third = common.nextSetBit(third + 1)) {
-                    if (startsWithT[first] || startsWithT[second] || startsWithT[third]) {
+        for (int a = 0; a < names.size(); a++) {
+            for (int b = graph.get(a).nextSetBit(a + 1); b >= 0; b = graph.get(a).nextSetBit(b + 1)) {
+                BitSet c = (BitSet) graph.get(a).clone();
+                c.and(graph.get(b));
+                for (int x = c.nextSetBit(b + 1); x >= 0; x = c.nextSetBit(x + 1)) {
+                    if (startsT[a] || startsT[b] || startsT[x]) {
                         total++;
                     }
                 }
@@ -74,78 +61,44 @@ public class Day23 extends DayTemplate {
         return total;
     }
 
-    private void findLargestClique() {
-        bestClique = new BitSet();
-        bestCliqueSize = 0;
-
-        BitSet candidates = new BitSet(names.size());
-        candidates.set(0, names.size());
-        bronKerbosch(new BitSet(names.size()), candidates, new BitSet(names.size()));
-    }
-
-    private void bronKerbosch(BitSet required, BitSet candidates, BitSet excluded) {
-        int requiredSize = required.cardinality();
-        if (requiredSize + candidates.cardinality() <= bestCliqueSize) {
+    private void clique(BitSet keep, BitSet can, BitSet skip) {
+        int size = keep.cardinality();
+        if (size + can.cardinality() <= bs) {
             return;
         }
-        if (candidates.isEmpty() && excluded.isEmpty()) {
-            if (requiredSize > bestCliqueSize) {
-                bestCliqueSize = requiredSize;
-                bestClique = (BitSet) required.clone();
-            }
+        if (can.isEmpty() && skip.isEmpty()) {
+            bs = size;
+            best = (BitSet) keep.clone();
             return;
         }
-
-        BitSet toVisit = (BitSet) candidates.clone();
-        int pivot = choosePivot(candidates, excluded);
-        if (pivot >= 0) {
-            toVisit.andNot(connections.get(pivot));
+        BitSet visit = (BitSet) can.clone();
+        int p = pivot(can, skip);
+        if (p >= 0) {
+            visit.andNot(graph.get(p));
         }
-
-        for (int vertex = toVisit.nextSetBit(0); vertex >= 0; vertex = toVisit.nextSetBit(vertex + 1)) {
-            BitSet nextRequired = (BitSet) required.clone();
-            nextRequired.set(vertex);
-
-            BitSet nextCandidates = (BitSet) candidates.clone();
-            nextCandidates.and(connections.get(vertex));
-
-            BitSet nextExcluded = (BitSet) excluded.clone();
-            nextExcluded.and(connections.get(vertex));
-
-            bronKerbosch(nextRequired, nextCandidates, nextExcluded);
-
-            candidates.clear(vertex);
-            excluded.set(vertex);
-            if (requiredSize + candidates.cardinality() <= bestCliqueSize) {
-                return;
-            }
+        for (int v = visit.nextSetBit(0); v >= 0; v = visit.nextSetBit(v + 1)) {
+            BitSet k = (BitSet) keep.clone(), c = (BitSet) can.clone(), s = (BitSet) skip.clone();
+            k.set(v);
+            c.and(graph.get(v));
+            s.and(graph.get(v));
+            clique(k, c, s);
+            can.clear(v);
+            skip.set(v);
         }
     }
 
-    private int choosePivot(BitSet candidates, BitSet excluded) {
-        BitSet choices = (BitSet) candidates.clone();
-        choices.or(excluded);
-
-        int bestPivot = -1;
-        int bestReach = -1;
-        for (int vertex = choices.nextSetBit(0); vertex >= 0; vertex = choices.nextSetBit(vertex + 1)) {
-            BitSet reachableCandidates = (BitSet) connections.get(vertex).clone();
-            reachableCandidates.and(candidates);
-            int reach = reachableCandidates.cardinality();
-            if (reach > bestReach) {
-                bestReach = reach;
-                bestPivot = vertex;
+    private int pivot(BitSet can, BitSet skip) {
+        BitSet all = (BitSet) can.clone();
+        all.or(skip);
+        int pick = -1, most = -1;
+        for (int v = all.nextSetBit(0); v >= 0; v = all.nextSetBit(v + 1)) {
+            BitSet reach = (BitSet) graph.get(v).clone();
+            reach.and(can);
+            if (reach.cardinality() > most) {
+                most = reach.cardinality();
+                pick = v;
             }
         }
-        return bestPivot;
-    }
-
-    private String cliqueToString(BitSet clique) {
-        List<String> cliqueNames = new ArrayList<>(clique.cardinality());
-        for (int index = clique.nextSetBit(0); index >= 0; index = clique.nextSetBit(index + 1)) {
-            cliqueNames.add(names.get(index));
-        }
-        Collections.sort(cliqueNames);
-        return String.join(",", cliqueNames);
+        return pick;
     }
 }

--- a/src/solutions/Day24.java
+++ b/src/solutions/Day24.java
@@ -5,8 +5,8 @@ import src.meta.DayTemplate;
 import java.util.*;
 
 public class Day24 extends DayTemplate {
-    private final Map<String, Integer> v = new HashMap<>();
-    private final List<I> ins = new ArrayList<>();
+    final Map<String, Integer> v = new HashMap<>();
+    final List<I> ins = new ArrayList<>();
 
     public String solve(boolean part1, Scanner in) {
         v.clear();
@@ -48,7 +48,7 @@ public class Day24 extends DayTemplate {
         return "" + Long.parseLong(bits.toString(), 2);
     }
 
-    private String swaps() {
+    String swaps() {
         int finalZ = ins.stream()
                 .filter(i -> i.o.startsWith("z"))
                 .mapToInt(i -> Integer.parseInt(i.o.substring(1)))
@@ -74,11 +74,11 @@ public class Day24 extends DayTemplate {
         return String.join(",", bad);
     }
 
-    private boolean isXY(String wire) {
+    boolean isXY(String wire) {
         return wire.startsWith("x") || wire.startsWith("y");
     }
 
-    private boolean feeds(String wire, String op) {
+    boolean feeds(String wire, String op) {
         for (I i : ins) {
             if (i.op.equals(op) && (i.a.equals(wire) || i.b.equals(wire))) {
                 return true;

--- a/src/solutions/Day24.java
+++ b/src/solutions/Day24.java
@@ -5,8 +5,8 @@ import src.meta.DayTemplate;
 import java.util.*;
 
 public class Day24 extends DayTemplate {
-    private final Map<String, Integer> map = new HashMap<>();
-    private final List<Instruction> instructions = new ArrayList<>();
+    private final Map<String, Integer> v = new HashMap<>();
+    private final List<I> ins = new ArrayList<>();
 
     public String solve(boolean part1, Scanner in) {
         for (boolean gates = false; in.hasNextLine();) {
@@ -14,27 +14,27 @@ public class Day24 extends DayTemplate {
             if (line.isEmpty()) {
                 gates = true;
             } else if (gates) {
-                instructions.add(new Instruction(line));
+                ins.add(new I(line));
             } else {
                 String[] p = line.split(": ");
-                map.put(p[0], Integer.parseInt(p[1]));
+                v.put(p[0], Integer.parseInt(p[1]));
             }
         }
         if (!part1) {
             swaps();
             return "";
         }
-        for (int n = 0; !instructions.isEmpty() && n++ < 100;) {
-            for (ListIterator<Instruction> it = instructions.listIterator(instructions.size()); it.hasPrevious();) {
-                Instruction i = it.previous();
-                if (map.containsKey(i.a) && map.containsKey(i.b)) {
-                    map.put(i.out, i.run(map));
+        for (int n = 0; !ins.isEmpty() && n++ < 100;) {
+            for (ListIterator<I> it = ins.listIterator(ins.size()); it.hasPrevious();) {
+                I i = it.previous();
+                if (v.containsKey(i.a) && v.containsKey(i.b)) {
+                    v.put(i.o, i.run(v));
                     it.remove();
                 }
             }
         }
         List<String> z = new ArrayList<>();
-        for (String k : map.keySet()) {
+        for (String k : v.keySet()) {
             if (k.startsWith("z")) {
                 z.add(k);
             }
@@ -42,79 +42,69 @@ public class Day24 extends DayTemplate {
         z.sort(Comparator.reverseOrder());
         StringBuilder bits = new StringBuilder();
         for (String k : z) {
-            bits.append(map.get(k));
+            bits.append(v.get(k));
         }
         return "" + Long.parseLong(bits.toString(), 2);
     }
 
     private void swaps() {
-        Map<String, Integer> gen = new HashMap<>(), prop = new HashMap<>(), or = new HashMap<>(),
-                and = new HashMap<>(), out = new HashMap<>();
-        Set<Instruction> bad = new HashSet<>();
-        and.put("fake0bitAND", 0);
-        for (ListIterator<Instruction> it = instructions.listIterator(instructions.size()); it.hasPrevious();) {
-            Instruction i = it.previous();
+        Map<String, Integer> gen = new HashMap<>(), prop = new HashMap<>(), or = new HashMap<>();
+        Set<I> bad = new HashSet<>();
+        for (ListIterator<I> it = ins.listIterator(ins.size()); it.hasPrevious();) {
+            I i = it.previous();
             if ((i.a.equals("x00") || i.a.equals("y00"))) {
-                (i.op.equals("AND") ? gen : prop).put(i.out, 0);
-                (i.op.equals("AND") ? or : out).put(i.out, 0);
-                it.remove();
-            }
-        }
-        for (ListIterator<Instruction> it = instructions.listIterator(instructions.size()); it.hasPrevious();) {
-            Instruction i = it.previous();
-            if (i.a.startsWith("x") || i.a.startsWith("y")) {
-                if (i.out.startsWith("z")) {
-                    bad.add(i);
-                } else {
-                    (i.op.equals("AND") ? gen : prop).put(i.out, Integer.parseInt(i.a.substring(1)));
+                (i.op.equals("AND") ? gen : prop).put(i.o, 0);
+                if (i.op.equals("AND")) {
+                    or.put(i.o, 0);
                 }
                 it.remove();
             }
         }
-        for (Instruction i : instructions) {
+        for (ListIterator<I> it = ins.listIterator(ins.size()); it.hasPrevious();) {
+            I i = it.previous();
+            if (i.a.startsWith("x") || i.a.startsWith("y")) {
+                if (i.o.startsWith("z")) {
+                    bad.add(i);
+                } else {
+                    (i.op.equals("AND") ? gen : prop).put(i.o, Integer.parseInt(i.a.substring(1)));
+                }
+                it.remove();
+            }
+        }
+        for (I i : ins) {
             if (i.op.equals("OR")) {
                 Integer n = gen.getOrDefault(i.a, gen.get(i.b));
                 if (n == null) {
                     bad.add(i);
                 } else {
-                    or.put(i.out, n);
+                    or.put(i.o, n);
                 }
             }
         }
-        for (Instruction i : instructions) {
+        for (I i : ins) {
             int n = link(prop, or, i);
-            if (i.op.equals("AND")) {
-                if (n < 0) {
-                    bad.add(i);
-                } else {
-                    and.put(i.out, n);
-                }
-            } else if (i.op.equals("XOR")) {
-                if (n < 0) {
-                    bad.add(i);
-                } else {
-                    out.put(i.out, n);
-                }
+            if ((i.op.equals("AND") || i.op.equals("XOR")) && n < 0) {
+                bad.add(i);
             }
         }
-        bad.stream().map(i -> i.out).sorted().forEach(System.out::println);
+        bad.stream().map(i -> i.o).sorted().forEach(System.out::println);
     }
 
-    private int link(Map<String, Integer> a, Map<String, Integer> b, Instruction i) {
+    private int link(Map<String, Integer> a, Map<String, Integer> b, I i) {
         return a.containsKey(i.a) && b.containsKey(i.b) ? a.get(i.a)
                 : a.containsKey(i.b) && b.containsKey(i.a) ? a.get(i.b) : -1;
     }
 }
 
-class Instruction {
-    String a, b, op, out;
+class I {
+    String a, b, op, o;
 
-    Instruction(String line) {
+    I(String line) {
         String[] p = line.split(" ");
         a = p[0];
         op = p[1];
         b = p[2];
-        out = p[4];
+        o = p[4];
     }
 
     int run(Map<String, Integer> map) {

--- a/src/solutions/Day24.java
+++ b/src/solutions/Day24.java
@@ -1,235 +1,128 @@
 package src.solutions;
 
 import src.meta.DayTemplate;
+
 import java.util.*;
 
 public class Day24 extends DayTemplate {
-
-
-    List<String> registers = new ArrayList<>();
-
-    Map<String, Integer> map = new HashMap<>();
-
-    List<Instruction> instructions = new ArrayList<>();
-
-    boolean hitEmpty = false;
+    private final Map<String, Integer> map = new HashMap<>();
+    private final List<Instruction> instructions = new ArrayList<>();
 
     public String solve(boolean part1, Scanner in) {
-        StringBuilder answer = new StringBuilder();
-        while (in.hasNext()) {
+        for (boolean gates = false; in.hasNextLine();) {
             String line = in.nextLine();
-            if(line.equals("")){
-                hitEmpty = true;
-                continue;
-            }
-            if(!hitEmpty){
-                Register r = new Register(line);
-                registers.add(r.name);
-                map.put(r.name, r.value);
-            }
-            else{
+            if (line.isEmpty()) {
+                gates = true;
+            } else if (gates) {
                 instructions.add(new Instruction(line));
+            } else {
+                String[] p = line.split(": ");
+                map.put(p[0], Integer.parseInt(p[1]));
             }
         }
-
-        if(part1){
-            int counter = 0;
-            while(!instructions.isEmpty() && counter++<100){
-                for(int i = instructions.size() - 1; i >= 0; i--){
-                    Instruction instruction = instructions.get(i);
-                    if (map.containsKey(instruction.firstReg) && map.containsKey(instruction.secondReg)) {
-                        map.put(instruction.output, instruction.run(map));
-                        instructions.remove(instruction);
-                    }
-                }
-            }
-            List<String> outputs = new ArrayList<>();
-
-            for(String key: map.keySet()){
-                if(key.startsWith("z")){
-                    outputs.add(key);
-                }
-            }
-            Collections.sort(outputs);
-            Collections.reverse(outputs);
-
-            for(String output: outputs){
-                answer.append(map.get(output));
-            }
-            answer = new StringBuilder(String.valueOf(Long.parseLong(answer.toString(), 2)));
+        if (!part1) {
+            swaps();
+            return "";
         }
-        else{
-            Map<String, Integer> generateBits = new HashMap<>(); //determines whether the current x and y bits will generate a carry
-            Map<String, Integer> propagateBits = new HashMap<>(); //determines whether the current carry will propagate up
-            Map<String, Integer> intermediateOrs = new HashMap<>(); //don't really know conceptually what it does, but only type of operation with OR
-            Map<String, Integer> intermediateAnds = new HashMap<>(); //the ANDs that don't involve x and y
-            Map<String, Integer> outputs = new HashMap<>(); //ops that involve z
-            Set<Instruction> potentialSwaps = new HashSet<>();
-
-            //special cases
-            intermediateAnds.put("fake0bitAND", 0); //there's no intermediate AND for the first bit
-            for(int i = instructions.size() - 1; i >= 0; i--) {
-                Instruction instruction = instructions.get(i);
-                if(instruction.firstReg.equals("x00") || instruction.firstReg.equals("y00")){
-                    if(instruction.operation.equals("XOR")){
-                        //x00 XOR y00 = z00 is kind of both an output and a propagate bit, since there's no carry
-                        outputs.put(instruction.output, 0);
-                        propagateBits.put(instruction.output, 0);
-                        instructions.remove(i);
-                    }
-                    if(instruction.operation.equals("AND")){
-                        //Similar to above, x00 AND y00 = ??? is kind of both an intermediate or and a generate bit, since there's no carry
-                        generateBits.put(instruction.output, 0);
-                        intermediateOrs.put(instruction.output, 0);
-                        instructions.remove(i);
-                    }
+        for (int n = 0; !instructions.isEmpty() && n++ < 100;) {
+            for (ListIterator<Instruction> it = instructions.listIterator(instructions.size()); it.hasPrevious();) {
+                Instruction i = it.previous();
+                if (map.containsKey(i.a) && map.containsKey(i.b)) {
+                    map.put(i.out, i.run(map));
+                    it.remove();
                 }
             }
-
-            //generate and propagates
-            for(int i = instructions.size() - 1; i >= 0; i--){
-                Instruction instruction = instructions.get(i);
-                if(instruction.firstReg.startsWith("x") || instruction.firstReg.startsWith("y")){ //x and y bits are always paired together since only the outputs are swapped
-                    if(instruction.output.startsWith("z")){
-                        potentialSwaps.add(instruction);
-                        continue;
-                    }
-                    if(instruction.operation.equals("AND")){
-                        generateBits.put(instruction.output, Integer.parseInt(instruction.firstReg.substring(1)));
-                    }
-                    else{ //always XOR, x and y bits are never used in an OR
-                        propagateBits.put(instruction.output, Integer.parseInt(instruction.firstReg.substring(1)));
-                    }
-                    instructions.remove(i);
-                }
-            }
-
-            //intermediate Ors
-            for(Instruction instruction: instructions){
-                if(instruction.operation.equals("OR")){
-                    if(generateBits.containsKey(instruction.firstReg)){
-                        int level = generateBits.get(instruction.firstReg);
-                        intermediateOrs.put(instruction.output, level);
-                        continue;
-                    }
-                    if(generateBits.containsKey(instruction.secondReg)){
-                        int level = generateBits.get(instruction.secondReg);
-                        intermediateOrs.put(instruction.output, level);
-                        continue;
-                    }
-                    potentialSwaps.add(instruction);
-                }
-            }
-
-           // intermediate ands and outputs
-            for(Instruction instruction: instructions){
-                if(instruction.operation.equals("AND")){
-                    if(propagateBits.containsKey(instruction.firstReg)){
-                        if(intermediateOrs.containsKey(instruction.secondReg)){
-                            int level = propagateBits.get(instruction.firstReg);
-                            intermediateAnds.put(instruction.output, level);
-                            continue;
-                        }
-                    }
-                    if(propagateBits.containsKey(instruction.secondReg)){
-                        if(intermediateOrs.containsKey(instruction.firstReg)){
-                            int level = propagateBits.get(instruction.secondReg);
-                            intermediateAnds.put(instruction.output, level);
-                            continue;
-                        }
-                    }
-                    potentialSwaps.add(instruction);
-                }
-                if(instruction.operation.equals("XOR")){
-                    if(propagateBits.containsKey(instruction.firstReg)){
-                        if(intermediateOrs.containsKey(instruction.secondReg)){
-                            int level = propagateBits.get(instruction.firstReg);
-                            outputs.put(instruction.output, level);
-                            continue;
-                        }
-                    }
-                    if(propagateBits.containsKey(instruction.secondReg)){
-                        if(intermediateOrs.containsKey(instruction.firstReg)){
-                            int level = propagateBits.get(instruction.secondReg);
-                            outputs.put(instruction.output, level);
-                            continue;
-                        }
-                    }
-                    potentialSwaps.add(instruction);
-                }
-            }
-//            for(int i = 0; i < registers.size()/2; i++){
-//                if(!propagateBits.containsValue(i)){
-//                    System.out.println("missing a propagate symbol for bit: " + i);
-//                }
-//                if(!generateBits.containsValue(i)){
-//                    System.out.println("missing a generate symbol for bit: " + i);
-//                }
-//                if(!intermediateOrs.containsValue(i)){
-//                    System.out.println("missing a intermediate or symbol for bit: " + i);
-//                }
-//                if(!intermediateAnds.containsValue(i)){
-//                    System.out.println("missing a intermediate and symbol for bit: " + i);
-//                }
-//                if(!outputs.containsValue(i)){
-//                    System.out.println("missing a output symbol for bit: " + i);
-//                }
-//            }
-
-            for(Instruction i: potentialSwaps){
-                System.out.println(i.output);
-            }
-
-
         }
-
-        return answer + "";
+        List<String> z = new ArrayList<>();
+        for (String k : map.keySet()) {
+            if (k.startsWith("z")) {
+                z.add(k);
+            }
+        }
+        z.sort(Comparator.reverseOrder());
+        StringBuilder bits = new StringBuilder();
+        for (String k : z) {
+            bits.append(map.get(k));
+        }
+        return "" + Long.parseLong(bits.toString(), 2);
     }
 
+    private void swaps() {
+        Map<String, Integer> gen = new HashMap<>(), prop = new HashMap<>(), or = new HashMap<>(),
+                and = new HashMap<>(), out = new HashMap<>();
+        Set<Instruction> bad = new HashSet<>();
+        and.put("fake0bitAND", 0);
+        for (ListIterator<Instruction> it = instructions.listIterator(instructions.size()); it.hasPrevious();) {
+            Instruction i = it.previous();
+            if ((i.a.equals("x00") || i.a.equals("y00"))) {
+                (i.op.equals("AND") ? gen : prop).put(i.out, 0);
+                (i.op.equals("AND") ? or : out).put(i.out, 0);
+                it.remove();
+            }
+        }
+        for (ListIterator<Instruction> it = instructions.listIterator(instructions.size()); it.hasPrevious();) {
+            Instruction i = it.previous();
+            if (i.a.startsWith("x") || i.a.startsWith("y")) {
+                if (i.out.startsWith("z")) {
+                    bad.add(i);
+                } else {
+                    (i.op.equals("AND") ? gen : prop).put(i.out, Integer.parseInt(i.a.substring(1)));
+                }
+                it.remove();
+            }
+        }
+        for (Instruction i : instructions) {
+            if (i.op.equals("OR")) {
+                Integer n = gen.getOrDefault(i.a, gen.get(i.b));
+                if (n == null) {
+                    bad.add(i);
+                } else {
+                    or.put(i.out, n);
+                }
+            }
+        }
+        for (Instruction i : instructions) {
+            int n = link(prop, or, i);
+            if (i.op.equals("AND")) {
+                if (n < 0) {
+                    bad.add(i);
+                } else {
+                    and.put(i.out, n);
+                }
+            } else if (i.op.equals("XOR")) {
+                if (n < 0) {
+                    bad.add(i);
+                } else {
+                    out.put(i.out, n);
+                }
+            }
+        }
+        bad.stream().map(i -> i.out).sorted().forEach(System.out::println);
+    }
 
-}
-
-class Register{
-    int value;
-    String name;
-
-    public Register(String line){
-        value = Integer.parseInt(line.split(": ")[1]);
-        name = line.split(": ")[0];
+    private int link(Map<String, Integer> a, Map<String, Integer> b, Instruction i) {
+        return a.containsKey(i.a) && b.containsKey(i.b) ? a.get(i.a)
+                : a.containsKey(i.b) && b.containsKey(i.a) ? a.get(i.b) : -1;
     }
 }
 
-class Instruction{
-    String firstReg;
-    String secondReg;
-    String operation;
+class Instruction {
+    String a, b, op, out;
 
-    String output;
-
-    public Instruction(String line){
-        String[] parts = line.split(" |->");
-        firstReg = parts[0];
-        secondReg = parts[2];
-        operation = parts[1];
-        output = parts[5];
+    Instruction(String line) {
+        String[] p = line.split(" ");
+        a = p[0];
+        op = p[1];
+        b = p[2];
+        out = p[4];
     }
 
-    public int run(Map<String, Integer> map){
-        int input1 = map.get(firstReg);
-        int input2 = map.get(secondReg);
-        if(operation.equals("AND")){
-            return input1 & input2;
-        }
-        if(operation.equals("OR")){
-            return input1 | input2;
-        }
-        if(operation.equals("XOR")){
-            return input1 ^ input2;
-        }
-        return -1;
-    }
-
-    public String toString(){
-        return firstReg + " " + operation + " " + secondReg + " " + output;
+    int run(Map<String, Integer> map) {
+        int x = map.get(a), y = map.get(b);
+        return switch (op) {
+            case "AND" -> x & y;
+            case "OR" -> x | y;
+            default -> x ^ y;
+        };
     }
 }

--- a/src/solutions/Day24.java
+++ b/src/solutions/Day24.java
@@ -9,6 +9,8 @@ public class Day24 extends DayTemplate {
     private final List<I> ins = new ArrayList<>();
 
     public String solve(boolean part1, Scanner in) {
+        v.clear();
+        ins.clear();
         for (boolean gates = false; in.hasNextLine();) {
             String line = in.nextLine();
             if (line.isEmpty()) {
@@ -21,8 +23,7 @@ public class Day24 extends DayTemplate {
             }
         }
         if (!part1) {
-            swaps();
-            return "";
+            return swaps();
         }
         for (int n = 0; !ins.isEmpty() && n++ < 100;) {
             for (ListIterator<I> it = ins.listIterator(ins.size()); it.hasPrevious();) {
@@ -47,52 +48,43 @@ public class Day24 extends DayTemplate {
         return "" + Long.parseLong(bits.toString(), 2);
     }
 
-    private void swaps() {
-        Map<String, Integer> gen = new HashMap<>(), prop = new HashMap<>(), or = new HashMap<>();
-        Set<I> bad = new HashSet<>();
-        for (ListIterator<I> it = ins.listIterator(ins.size()); it.hasPrevious();) {
-            I i = it.previous();
-            if ((i.a.equals("x00") || i.a.equals("y00"))) {
-                (i.op.equals("AND") ? gen : prop).put(i.o, 0);
-                if (i.op.equals("AND")) {
-                    or.put(i.o, 0);
-                }
-                it.remove();
-            }
-        }
-        for (ListIterator<I> it = ins.listIterator(ins.size()); it.hasPrevious();) {
-            I i = it.previous();
-            if (i.a.startsWith("x") || i.a.startsWith("y")) {
-                if (i.o.startsWith("z")) {
-                    bad.add(i);
-                } else {
-                    (i.op.equals("AND") ? gen : prop).put(i.o, Integer.parseInt(i.a.substring(1)));
-                }
-                it.remove();
-            }
-        }
+    private String swaps() {
+        int finalZ = ins.stream()
+                .filter(i -> i.o.startsWith("z"))
+                .mapToInt(i -> Integer.parseInt(i.o.substring(1)))
+                .max()
+                .orElseThrow();
+        Set<String> bad = new TreeSet<>();
         for (I i : ins) {
-            if (i.op.equals("OR")) {
-                Integer n = gen.getOrDefault(i.a, gen.get(i.b));
-                if (n == null) {
-                    bad.add(i);
-                } else {
-                    or.put(i.o, n);
-                }
+            boolean firstInputBit = i.a.equals("x00") || i.a.equals("y00");
+            boolean xyInput = isXY(i.a) && isXY(i.b);
+            if (i.o.startsWith("z") && Integer.parseInt(i.o.substring(1)) != finalZ && !i.op.equals("XOR")) {
+                bad.add(i.o);
+            }
+            if (i.op.equals("XOR") && !xyInput && !i.o.startsWith("z")) {
+                bad.add(i.o);
+            }
+            if (i.op.equals("AND") && !firstInputBit && !feeds(i.o, "OR")) {
+                bad.add(i.o);
+            }
+            if (i.op.equals("XOR") && xyInput && !firstInputBit && (!feeds(i.o, "XOR") || !feeds(i.o, "AND"))) {
+                bad.add(i.o);
             }
         }
-        for (I i : ins) {
-            int n = link(prop, or, i);
-            if ((i.op.equals("AND") || i.op.equals("XOR")) && n < 0) {
-                bad.add(i);
-            }
-        }
-        bad.stream().map(i -> i.o).sorted().forEach(System.out::println);
+        return String.join(",", bad);
     }
 
-    private int link(Map<String, Integer> a, Map<String, Integer> b, I i) {
-        return a.containsKey(i.a) && b.containsKey(i.b) ? a.get(i.a)
-                : a.containsKey(i.b) && b.containsKey(i.a) ? a.get(i.b) : -1;
+    private boolean isXY(String wire) {
+        return wire.startsWith("x") || wire.startsWith("y");
+    }
+
+    private boolean feeds(String wire, String op) {
+        for (I i : ins) {
+            if (i.op.equals(op) && (i.a.equals(wire) || i.b.equals(wire))) {
+                return true;
+            }
+        }
+        return false;
     }
 }
 

--- a/src/solutions/Day25.java
+++ b/src/solutions/Day25.java
@@ -9,7 +9,7 @@ import java.util.Scanner;
 public class Day25 extends DayTemplate {
 
     public String solve(boolean part1, Scanner in){
-        if(!part1) { //part 2 doesn't exist for this day
+        if(!part1) {
             return "Merry Christmas!";
         }
         long answer = 0;


### PR DESCRIPTION
## Summary
- shrink 2024 Day01-12, Day14-21, Day23, and Day24 solution implementations while preserving one-file-per-day structure
- replace performance-oriented scaffolding with more compact standard-library or direct implementations where the logic stays readable
- reduce Day01-Day25 non-whitespace character total from 61,025 at the starting point to 30,487, below the 50% target of 30,512

## Verification
- javac -d /private/tmp/aoc2024-size-classes src/meta/*.java src/objects/*.java src/solutions/*.java
- java -cp /private/tmp/aoc-compare-classes AocCompare /private/tmp/aoc2024-size-check-base-classes /private/tmp/aoc2024-size-classes /private/tmp/aoc2024-performance-20260705/data -> All outputs match

Note: Day09 still emits the existing unchecked generic-array warning from its priority queue bucket array.